### PR TITLE
chore: Fix action workflows to use the latest version

### DIFF
--- a/.github/workflows/test_vscode.yml
+++ b/.github/workflows/test_vscode.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16.x
       - run: npm ci

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -18,14 +18,13 @@ jobs:
         node: [18, 20]
         exclude:
           - os: windows-latest
-            node: "17"
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 


### PR DESCRIPTION
The old versions were no longer supported on GitHub Actions.

Also node: "17" was not in the list of node versions to exclude in the strategy.

Validated the changes on this nice tool:
https://rhysd.github.io/actionlint/
