### PR TITLE
fix: Add missing awaits to test cases

### DIFF
--- a/packages/vscode-lit-plugin/src/test/simple-test.ts
+++ b/packages/vscode-lit-plugin/src/test/simple-test.ts
@@ -34,8 +34,8 @@ suite("Extension Test Suite", () => {
 
 	test("We produce a diagnostic", async () => {
 		const config = vscode.workspace.getConfiguration();
-		config.update("lit-plugin.logging", "verbose", true);
-		config.update("lit-plugin.rules.no-missing-element-type-definition", "error", true);
+		await config.update("lit-plugin.logging", "verbose", true);
+		await config.update("lit-plugin.rules.no-missing-element-type-definition", "error", true);
 		const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(__dirname, "../../src/test/fixtures/missing-elem-type.ts")));
 		await vscode.window.showTextDocument(doc);
 
@@ -48,8 +48,8 @@ suite("Extension Test Suite", () => {
 
 	test("We detect no-missing-import properly", async () => {
 		const config = vscode.workspace.getConfiguration();
-		config.update("lit-plugin.logging", "verbose", true);
-		config.update("lit-plugin.rules.no-missing-import", "error", true);
+		await config.update("lit-plugin.logging", "verbose", true);
+		await config.update("lit-plugin.rules.no-missing-import", "error", true);
 		const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(__dirname, "../../src/test/fixtures/missing-import.ts")));
 		const editor = await vscode.window.showTextDocument(doc);
 
@@ -71,7 +71,7 @@ suite("Extension Test Suite", () => {
 		// give it some time to settle
 		await new Promise(resolve => setTimeout(resolve, 1000));
 
-		assert.rejects(getDiagnostics(doc.uri, 3), "Expected rejection as no diagnostics will be found.");
+		await assert.rejects(getDiagnostics(doc.uri, 3), "Expected rejection as no diagnostics will be found.");
 	});
 
 	test("We generate completions", async () => {


### PR DESCRIPTION
Related to this error log on the `macos-latest` environment:
```shell
Extension Test Suite
    ✔ The extension is installed
    1) We produce a diagnostic
    2) We detect no-missing-import properly
    ✔ We generate completions (324ms)
  2 passing (2m)
Error: 2 tests failed.
  2 failing
	at Object.<anonymous> (/Users/runner/work/lit-analyzer/lit-analyzer/packages/vscode-lit-plugin/out/test/scripts/mocha-driver.js:65:19)
  1) Extension Test Suite
	at Generator.next (<anonymous>)
	at fulfilled (/Users/runner/work/lit-analyzer/lit-analyzer/packages/vscode-lit-plugin/out/test/scripts/mocha-driver.js:28:58)
Extension host test runner error Error: 2 tests failed.
	at Object.<anonymous> (/Users/runner/work/lit-analyzer/lit-analyzer/packages/vscode-lit-plugin/out/test/scripts/mocha-driver.js:65:19)
	at Generator.next (<anonymous>)
	at fulfilled (/Users/runner/work/lit-analyzer/lit-analyzer/packages/vscode-lit-plugin/out/test/scripts/mocha-driver.js:28:58)
       We produce a diagnostic:
     Error: Timeout of 60000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/lit-analyzer/lit-analyzer/packages/vscode-lit-plugin/out/test/simple-test.js)
  	at listOnTimeout (node:internal/timers:581:17)
  	at process.processTimers (node:internal/timers:519:7)

  2) Extension Test Suite
       We detect no-missing-import properly:
     Error: Timeout of 60000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/lit-analyzer/lit-analyzer/packages/vscode-lit-plugin/out/test/simple-test.js)
  	at listOnTimeout (node:internal/timers:581:17)
  	at process.processTimers (node:internal/timers:519:7)
```