### PR TITLE
chore: Uninstall rimraf and nodemon devDependencies

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -27,7 +27,6 @@
 			"devDependencies": {
 				"@types/node": "^22.10.2",
 				"esbuild": "^0.14.34",
-				"rimraf": "^3.0.2",
 				"typescript": "~5.2.2",
 				"wireit": "^0.1.1"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
 				"husky": "^4.2.5",
 				"lerna": "^8.1.9",
 				"lint-staged": "^15.2.11",
-				"nodemon": "^3.1.9",
 				"prettier": "^2.4.1",
 				"typescript": "~5.2.2",
 				"wireit": "^0.9.5"
@@ -2767,11 +2766,6 @@
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
 			}
-		},
-		"node_modules/abbrev": {
-			"version": "1.1.1",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/acorn": {
 			"version": "8.14.0",
@@ -6489,11 +6483,6 @@
 				"node": ">= 4"
 			}
 		},
-		"node_modules/ignore-by-default": {
-			"version": "1.0.1",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/ignore-walk": {
 			"version": "6.0.5",
 			"dev": true,
@@ -9683,52 +9672,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/nodemon": {
-			"version": "3.1.9",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chokidar": "^3.5.2",
-				"debug": "^4",
-				"ignore-by-default": "^1.0.1",
-				"minimatch": "^3.1.2",
-				"pstree.remy": "^1.1.8",
-				"semver": "^7.5.3",
-				"simple-update-notifier": "^2.0.0",
-				"supports-color": "^5.5.0",
-				"touch": "^3.1.0",
-				"undefsafe": "^2.0.5"
-			},
-			"bin": {
-				"nodemon": "bin/nodemon.js"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/nodemon"
-			}
-		},
-		"node_modules/nodemon/node_modules/has-flag": {
-			"version": "3.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/nodemon/node_modules/supports-color": {
-			"version": "5.5.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/nofilter": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
@@ -11092,11 +11035,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/pstree.remy": {
-			"version": "1.1.8",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/pump": {
 			"version": "3.0.0",
 			"dev": true,
@@ -11923,17 +11861,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/simple-update-notifier": {
-			"version": "2.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"semver": "^7.5.3"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/slash": {
 			"version": "3.0.0",
 			"dev": true,
@@ -12618,28 +12545,6 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/touch": {
-			"version": "3.1.0",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"nopt": "~1.0.10"
-			},
-			"bin": {
-				"nodetouch": "bin/nodetouch.js"
-			}
-		},
-		"node_modules/touch/node_modules/nopt": {
-			"version": "1.0.10",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"abbrev": "1"
-			},
-			"bin": {
-				"nopt": "bin/nopt.js"
-			}
-		},
 		"node_modules/tr46": {
 			"version": "0.0.3",
 			"dev": true,
@@ -12929,11 +12834,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/undefsafe": {
-			"version": "2.0.5",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/underscore": {
 			"version": "1.13.7",
@@ -13601,7 +13501,6 @@
 			"devDependencies": {
 				"@types/node": "^22.10.2",
 				"ava": "^6.2.0",
-				"rimraf": "^3.0.2",
 				"tslib": "^2.0.0",
 				"typescript": "~5.2.2",
 				"typescript-4.8": "npm:typescript@~4.8.2",
@@ -13635,7 +13534,6 @@
 			"devDependencies": {
 				"@types/node": "^22.10.2",
 				"esbuild": "^0.14.34",
-				"rimraf": "^3.0.2",
 				"typescript": "~5.2.2",
 				"wireit": "^0.1.1"
 			}

--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
 		"husky": "^4.2.5",
 		"lerna": "^8.1.9",
 		"lint-staged": "^15.2.11",
-		"nodemon": "^3.1.9",
 		"prettier": "^2.4.1",
 		"typescript": "~5.2.2",
 		"wireit": "^0.9.5"

--- a/packages/lit-analyzer/package.json
+++ b/packages/lit-analyzer/package.json
@@ -101,7 +101,6 @@
 	"devDependencies": {
 		"@types/node": "^22.10.2",
 		"ava": "^6.2.0",
-		"rimraf": "^3.0.2",
 		"tslib": "^2.0.0",
 		"typescript": "~5.2.2",
 		"typescript-4.8": "npm:typescript@~4.8.2",

--- a/packages/ts-lit-plugin/package.json
+++ b/packages/ts-lit-plugin/package.json
@@ -60,7 +60,6 @@
 	"devDependencies": {
 		"@types/node": "^22.10.2",
 		"esbuild": "^0.14.34",
-		"rimraf": "^3.0.2",
 		"typescript": "~5.2.2",
 		"wireit": "^0.1.1"
 	},


### PR DESCRIPTION
Neither of these are being used any longer, so removing them to clean things up a little.