### PR TITLE
Renaming NPM Packages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Hi there, I really appreciate you considering contributing to this repository! This readme hopefully contains what you need to get started. If you have any questions please open an issue or PM me on twitter [@RuneMehlsen](https://twitter.com/RuneMehlsen).
 
-1. Clone the monorepo: `git clone https://github.com/runem/lit-analyzer.git`
+1. Clone the monorepo: `git clone https://github.com/JackRobards/lit-analyzer.git`
 2. Install dependencies: `npm ci`
 3. Run tests: `npm test`
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 <p align="center">
 		<a href="https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin"><img alt="Downloads per Month" src="https://vsmarketplacebadges.dev/downloads-short/runem.lit-plugin.svg?label=vscode-lit-plugin" height="20"/></a>
-<a href="https://www.npmjs.com/package/lit-analyzer"><img alt="Downloads per Month" src="https://img.shields.io/npm/dm/lit-analyzer.svg?label=lit-analyzer" height="20"/></a>
-<a href="https://www.npmjs.com/package/ts-lit-plugin"><img alt="Downloads per Month" src="https://img.shields.io/npm/dm/ts-lit-plugin.svg?label=ts-lit-plugin" height="20"/></a>
-<a href="https://github.com/runem/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/runem/lit-analyzer" height="20"/></a>
+<a href="https://www.npmjs.com/package/lit-analyzer-fork"><img alt="Downloads per Month" src="https://img.shields.io/npm/dm/lit-analyzer.svg?label=lit-analyzer" height="20"/></a>
+<a href="https://www.npmjs.com/package/ts-lit-plugin-fork"><img alt="Downloads per Month" src="https://img.shields.io/npm/dm/ts-lit-plugin-fork.svg?label=ts-lit-plugin-fork" height="20"/></a>
+<a href="https://github.com/runem/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/JackRobards/lit-analyzer" height="20"/></a>
 	</p>
 
 This mono-repository consists of the following tools:

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 <p align="center">
 		<a href="https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin"><img alt="Downloads per Month" src="https://vsmarketplacebadges.dev/downloads-short/runem.lit-plugin.svg?label=vscode-lit-plugin" height="20"/></a>
-<a href="https://www.npmjs.com/package/lit-analyzer-fork"><img alt="Downloads per Month" src="https://img.shields.io/npm/dm/lit-analyzer.svg?label=lit-analyzer" height="20"/></a>
+<a href="https://www.npmjs.com/package/lit-analyzer-fork"><img alt="Downloads per Month" src="https://img.shields.io/npm/dm/lit-analyzer-fork.svg?label=lit-analyzer-fork" height="20"/></a>
 <a href="https://www.npmjs.com/package/ts-lit-plugin-fork"><img alt="Downloads per Month" src="https://img.shields.io/npm/dm/ts-lit-plugin-fork.svg?label=ts-lit-plugin-fork" height="20"/></a>
-<a href="https://github.com/runem/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/JackRobards/lit-analyzer" height="20"/></a>
+<a href="https://github.com/JackRobards/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/JackRobards/lit-analyzer" height="20"/></a>
 	</p>
 
 This mono-repository consists of the following tools:
@@ -25,7 +25,7 @@ This mono-repository consists of the following tools:
 
 ## ➤ Rules
 
-You can find a list of all rules [here](https://github.com/runem/lit-analyzer/blob/master/docs/readme/rules.md).
+You can find a list of all rules [here](https://github.com/JackRobards/lit-analyzer/blob/master/docs/readme/rules.md).
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png)](#contributing)
 
@@ -37,9 +37,9 @@ If you are interested in contributing to this repository please read [`contribut
 
 ## ➤ Contributors
 
-| [<img alt="Rune Mehlsen" src="https://avatars2.githubusercontent.com/u/5372940?s=460&v=4" width="100">](https://twitter.com/runemehlsen) | [<img alt="Andreas Mehlsen" src="https://avatars1.githubusercontent.com/u/6267397?s=460&v=4" width="100">](https://twitter.com/andreasmehlsen) | [<img alt="Peter Burns" src="https://avatars3.githubusercontent.com/u/1659?s=460&v=4" width="100">](https://twitter.com/rictic) | [<img alt="You?" src="https://joeschmoe.io/api/v1/random" width="100">](https://github.com/runem/lit-analyzer/blob/master/CONTRIBUTING.md) |
-| :--------------------------------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------------------: |
-|                                             [Rune Mehlsen](https://twitter.com/runemehlsen)                                              |                                             [Andreas Mehlsen](https://twitter.com/andreasmehlsen)                                              |                                            [Peter Burns](https://twitter.com/rictic)                                            |                                 [You?](https://github.com/runem/lit-analyzer/blob/master/CONTRIBUTING.md)                                  |
+| [<img alt="Rune Mehlsen" src="https://avatars2.githubusercontent.com/u/5372940?s=460&v=4" width="100">](https://twitter.com/runemehlsen) | [<img alt="Andreas Mehlsen" src="https://avatars1.githubusercontent.com/u/6267397?s=460&v=4" width="100">](https://twitter.com/andreasmehlsen) | [<img alt="Peter Burns" src="https://avatars3.githubusercontent.com/u/1659?s=460&v=4" width="100">](https://twitter.com/rictic) | [<img alt="You?" src="https://joeschmoe.io/api/v1/random" width="100">](https://github.com/JackRobards/lit-analyzer/blob/master/CONTRIBUTING.md) |
+| :--------------------------------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------------------------: |
+|                                             [Rune Mehlsen](https://twitter.com/runemehlsen)                                              |                                             [Andreas Mehlsen](https://twitter.com/andreasmehlsen)                                              |                                            [Peter Burns](https://twitter.com/rictic)                                            |                                 [You?](https://github.com/JackRobards/lit-analyzer/blob/master/CONTRIBUTING.md)                                  |
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png)](#license)
 

--- a/dev/package.json
+++ b/dev/package.json
@@ -5,7 +5,7 @@
 	"dependencies": {
 		"lit-element": "^2.3.1",
 		"lit-html": "^1.2.1",
-		"ts-lit-plugin": "file:../packages/ts-lit-plugin"
+		"ts-lit-plugin-fork": "file:../packages/ts-lit-plugin"
 	},
 	"devDependencies": {
 		"typescript": "~5.7.2"

--- a/dev/tsconfig.json
+++ b/dev/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"plugins": [
 			{
-				"name": "ts-lit-plugin",
+				"name": "ts-lit-plugin-fork",
 				"logging": "verbose",
 				"strict": true,
 				"cssTemplateTags": ["css", "scss", "sass"],

--- a/docs/readme/config-table.md
+++ b/docs/readme/config-table.md
@@ -1,7 +1,7 @@
 <!-- prettier-ignore -->
 | Option | Description | Type | Default |
 | :----- | ----------- | ---- | ------- |
-| `strict` | Enabling strict mode will change which rules are applied as default (see list of [rules](https://github.com/runem/lit-analyzer/blob/master/docs/readme/rules.md)) | `boolean` | false |
+| `strict` | Enabling strict mode will change which rules are applied as default (see list of [rules](https://github.com/JackRobards/lit-analyzer/blob/master/docs/readme/rules.md)) | `boolean` | false |
 | `rules` | Enable/disable individual rules or set their severity. Example: `{"no-unknown-tag-name": "off"}` | `{"rule-name": "off" \| "warn" \| "error"}` | The default rules enabled depend on the `strict` option |
 | `disable` | Completely disable this plugin. | `boolean` | false |
 | `dontShowSuggestions` | This option sets strict as  | `boolean` | false |

--- a/docs/readme/jsdoc.md
+++ b/docs/readme/jsdoc.md
@@ -1,6 +1,6 @@
 ## Documenting slots, events, attributes and properties
 
-Code is analyzed using [web-component-analyzer](https://github.com/runem/web-component-analyzer) in order to find properties, attributes and events. Unfortunately, sometimes it's not possible to analyze these things by looking at the code, and you will have to document how your component looks using `jsdoc`like this:
+Code is analyzed using [web-component-analyzer](https://github.com/JackRobards/lit-analyzer/tree/master/packages/web-component-analyzer) in order to find properties, attributes and events. Unfortunately, sometimes it's not possible to analyze these things by looking at the code, and you will have to document how your component looks using `jsdoc`like this:
 
 <!-- prettier-ignore -->
 ```js

--- a/docs/readme/rules.md
+++ b/docs/readme/rules.md
@@ -58,7 +58,7 @@ Each rule can have severity of `off`, `warning` or `error`. You can toggle rules
 
 ### Validating custom elements
 
-All web components in your code are analyzed using [web-component-analyzer](https://github.com/runem/web-component-analyzer) which supports native custom elements and web components built with LitElement.
+All web components in your code are analyzed using [web-component-analyzer](https://github.com/JackRobards/lit-analyzer/tree/master/packages/web-component-analyzer) which supports native custom elements and web components built with LitElement.
 
 #### 🤷‍ no-unknown-tag-name
 
@@ -154,7 +154,7 @@ declare global {
 
 ### Validating binding names
 
-Attributes, properties and events are picked up on custom elements using [web-component-analyzer](https://github.com/runem/web-component-analyzer) which supports native custom elements and web components built with LitElement.
+Attributes, properties and events are picked up on custom elements using [web-component-analyzer](https://github.com/JackRobards/lit-analyzer/tree/master/packages/web-component-analyzer) which supports native custom elements and web components built with LitElement.
 
 #### ✅ no-unknown-attribute, no-unknown-property
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "lit-analyzer",
+	"name": "lit-analyzer-fork",
 	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "lit-analyzer",
+			"name": "lit-analyzer-fork",
 			"version": "1.0.0",
 			"license": "MIT",
 			"workspaces": [
@@ -9243,7 +9243,7 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
-		"node_modules/lit-analyzer": {
+		"node_modules/lit-analyzer-fork": {
 			"resolved": "packages/lit-analyzer",
 			"link": true
 		},
@@ -14604,6 +14604,7 @@
 			}
 		},
 		"packages/lit-analyzer": {
+			"name": "lit-analyzer-fork",
 			"version": "2.0.3",
 			"license": "MIT",
 			"dependencies": {
@@ -14618,7 +14619,7 @@
 				"web-component-analyzer": "^2.0.0"
 			},
 			"bin": {
-				"lit-analyzer": "cli.js"
+				"lit-analyzer-fork": "cli.js"
 			},
 			"devDependencies": {
 				"@types/node": "^22.10.2",
@@ -14636,7 +14637,7 @@
 			"version": "2.0.2",
 			"license": "MIT",
 			"dependencies": {
-				"lit-analyzer": "^2.0.1",
+				"lit-analyzer-fork": "^2.0.1",
 				"web-component-analyzer": "^2.0.0"
 			},
 			"devDependencies": {
@@ -14675,7 +14676,7 @@
 				"@vscode/vsce": "^3.2.1",
 				"esbuild": "^0.24.2",
 				"fast-glob": "^3.2.11",
-				"lit-analyzer": "^2.0.3",
+				"lit-analyzer-fork": "^2.0.3",
 				"mocha": "^11.0.1",
 				"wireit": "^0.1.1"
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -13612,7 +13612,7 @@
 				"typescript": ">=4.2.0"
 			}
 		},
-		"node_modules/ts-lit-plugin": {
+		"node_modules/ts-lit-plugin-fork": {
 			"resolved": "packages/ts-lit-plugin",
 			"link": true
 		},
@@ -14112,7 +14112,7 @@
 				"defaults": "^1.0.3"
 			}
 		},
-		"node_modules/web-component-analyzer": {
+		"node_modules/web-component-analyzer-fork": {
 			"resolved": "packages/web-component-analyzer",
 			"link": true
 		},
@@ -14616,7 +14616,7 @@
 				"ts-simple-type": "~2.0.0-next.0",
 				"vscode-css-languageservice": "6.3.2",
 				"vscode-html-languageservice": "5.3.1",
-				"web-component-analyzer": "^2.0.0"
+				"web-component-analyzer-fork": "^2.0.0"
 			},
 			"bin": {
 				"lit-analyzer-fork": "cli.js"
@@ -14634,11 +14634,12 @@
 			}
 		},
 		"packages/ts-lit-plugin": {
+			"name": "ts-lit-plugin-fork",
 			"version": "2.0.2",
 			"license": "MIT",
 			"dependencies": {
 				"lit-analyzer-fork": "^2.0.1",
-				"web-component-analyzer": "^2.0.0"
+				"web-component-analyzer-fork": "^2.0.0"
 			},
 			"devDependencies": {
 				"@types/node": "^22.10.2",
@@ -14700,6 +14701,7 @@
 			}
 		},
 		"packages/web-component-analyzer": {
+			"name": "web-component-analyzer-fork",
 			"version": "2.0.0",
 			"license": "MIT",
 			"dependencies": {
@@ -14710,7 +14712,7 @@
 			},
 			"bin": {
 				"wca": "cli.js",
-				"web-component-analyzer": "cli.js"
+				"web-component-analyzer-fork": "cli.js"
 			},
 			"devDependencies": {
 				"@rollup/plugin-node-resolve": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-	"name": "lit-analyzer",
+	"name": "lit-analyzer-fork",
 	"version": "1.0.0",
-	"description": "Monorepo for tools that analyze lit-html templates",
+	"description": "Monorepo for tools that analyze lit-html templates. Updated fork of the original lit-analyzer.",
 	"private": true,
-	"author": "runem",
+	"author": "JackRobards",
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/runem/lit-analyzer.git"
+		"url": "https://github.com/JackRobards/lit-analyzer.git"
 	},
 	"workspaces": [
 		"packages/lit-analyzer",
@@ -16,9 +16,9 @@
 		"packages/web-component-analyzer"
 	],
 	"bugs": {
-		"url": "https://github.com/runem/lit-analyzer/issues"
+		"url": "https://github.com/JackRobards/lit-analyzer/issues"
 	},
-	"homepage": "https://github.com/runem/lit-analyzer#readme",
+	"homepage": "https://github.com/JackRobards/lit-analyzer#readme",
 	"keywords": [
 		"lit-html",
 		"lit",
@@ -153,7 +153,7 @@
 		{
 			"name": "You?",
 			"img": "https://joeschmoe.io/api/v1/random",
-			"url": "https://github.com/runem/lit-analyzer/blob/master/CONTRIBUTING.md"
+			"url": "https://github.com/JackRobards/lit-analyzer/blob/master/CONTRIBUTING.md"
 		}
 	]
 }

--- a/packages/lit-analyzer/README.md
+++ b/packages/lit-analyzer/README.md
@@ -25,7 +25,7 @@ npm install lit-analyzer -g
 **Note:**
 
 - If you use Visual Studio Code you can also install the [lit-plugin](https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin) extension.
-- If you use Typescript you can also install [ts-lit-plugin](https://github.com/runem/lit-analyzer/blob/master/packages/ts-lit-plugin).
+- If you use Typescript you can also install [ts-lit-plugin-fork](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin).
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png)](#usage)
 
@@ -52,7 +52,7 @@ You can configure the CLI with arguments:
 lit-analyzer --strict --rules.no-unknown-tag-name off --format markdown
 ```
 
-**Note:** You can also configure the CLI using a `tsconfig.json` file (see [ts-lit-plugin](https://github.com/runem/lit-analyzer/blob/master/packages/ts-lit-plugin)).
+**Note:** You can also configure the CLI using a `tsconfig.json` file (see [ts-lit-plugin-fork](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin)).
 
 ### Available arguments
 

--- a/packages/lit-analyzer/README.md
+++ b/packages/lit-analyzer/README.md
@@ -7,10 +7,10 @@
 <br />
 
 <p align="center">
-		<a href="https://npmcharts.com/compare/lit-analyzer?minimal=true"><img alt="Downloads per month" src="https://img.shields.io/npm/dm/lit-analyzer.svg" height="20"/></a>
-<a href="https://www.npmjs.com/package/lit-analyzer"><img alt="NPM Version" src="https://img.shields.io/npm/v/lit-analyzer.svg" height="20"/></a>
-<a href="https://david-dm.org/runem/lit-analyzer"><img alt="Dependencies" src="https://img.shields.io/david/runem/lit-analyzer.svg" height="20"/></a>
-<a href="https://github.com/runem/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/runem/lit-analyzer.svg" height="20"/></a>
+		<a href="https://npmcharts.com/compare/lit-analyzer-fork?minimal=true"><img alt="Downloads per month" src="https://img.shields.io/npm/dm/lit-analyzer-fork.svg" height="20"/></a>
+<a href="https://www.npmjs.com/package/lit-analyzer-fork"><img alt="NPM Version" src="https://img.shields.io/npm/v/lit-analyzer-fork.svg" height="20"/></a>
+<a href="https://david-dm.org/JackRobards/lit-analyzer"><img alt="Dependencies" src="https://img.shields.io/david/JackRobards/lit-analyzer.svg" height="20"/></a>
+<a href="https://github.com/JackRobards/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/JackRobards/lit-analyzer.svg" height="20"/></a>
 	</p>
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png)](#installation)
@@ -60,7 +60,7 @@ lit-analyzer --strict --rules.no-unknown-tag-name off --format markdown
 | Option | Description | Type | Default |
 | :----- | ----------- | ---- | ------- |
 | `--help` | Print help message | `boolean` | |
-| `--rules.rule-name` | Enable or disable rules (example: --rules.no-unknown-tag-name off). Severity can be "off" \| "warn" \| "error". See a list of rules [here](https://github.com/runem/lit-analyzer/blob/master/docs/readme/rules.md). | `{"rule-name": "off" \| "warn" \| "error"}` |  |
+| `--rules.rule-name` | Enable or disable rules (example: --rules.no-unknown-tag-name off). Severity can be "off" \| "warn" \| "error". See a list of rules [here](https://github.com/JackRobards/lit-analyzer/blob/master/docs/readme/rules.md). | `{"rule-name": "off" \| "warn" \| "error"}` |  |
 | `--strict` | Enable strict mode. This changes the default ruleset | `boolean` | |
 | `--format` | Change the format of how diagnostics are reported | `code` \| `list` \| `markdown` | code |
 | `--maxWarnings` | Fail only when the number of warnings is larger than this number | `number` | -1 |
@@ -131,7 +131,7 @@ Each rule can have severity of `off`, `warning` or `error`. You can toggle rules
 
 ### Validating custom elements
 
-All web components in your code are analyzed using [web-component-analyzer](https://github.com/runem/web-component-analyzer) which supports native custom elements and web components built with LitElement.
+All web components in your code are analyzed using [web-component-analyzer](https://github.com/JackRobards/lit-analyzer/tree/master/packages/web-component-analyzer) which supports native custom elements and web components built with LitElement.
 
 #### 🤷‍ no-unknown-tag-name
 
@@ -227,7 +227,7 @@ declare global {
 
 ### Validating binding names
 
-Attributes, properties and events are picked up on custom elements using [web-component-analyzer](https://github.com/runem/web-component-analyzer) which supports native custom elements and web components built with LitElement.
+Attributes, properties and events are picked up on custom elements using [web-component-analyzer](https://github.com/JackRobards/lit-analyzer/tree/master/packages/web-component-analyzer) which supports native custom elements and web components built with LitElement.
 
 #### ✅ no-unknown-attribute, no-unknown-property
 
@@ -687,7 +687,7 @@ css`
 
 ## ➤ Documenting slots, events, attributes and properties
 
-Code is analyzed using [web-component-analyzer](https://github.com/runem/web-component-analyzer) in order to find properties, attributes and events. Unfortunately, sometimes it's not possible to analyze these things by looking at the code, and you will have to document how your component looks using `jsdoc`like this:
+Code is analyzed using [web-component-analyzer](https://github.com/JackRobards/lit-analyzer/tree/master/packages/web-component-analyzer) in order to find properties, attributes and events. Unfortunately, sometimes it's not possible to analyze these things by looking at the code, and you will have to document how your component looks using `jsdoc`like this:
 
 <!-- prettier-ignore -->
 ```js
@@ -715,9 +715,9 @@ customElements.define("my-element", MyElement);
 
 ## ➤ Contributors
 
-| [<img alt="Rune Mehlsen" src="https://avatars2.githubusercontent.com/u/5372940?s=460&v=4" width="100">](https://twitter.com/runemehlsen) | [<img alt="Andreas Mehlsen" src="https://avatars1.githubusercontent.com/u/6267397?s=460&v=4" width="100">](https://twitter.com/andreasmehlsen) | [<img alt="You?" src="https://joeschmoe.io/api/v1/random" width="100">](https://github.com/runem/lit-analyzer/blob/master/CONTRIBUTING.md) |
-| :--------------------------------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------------------: |
-|                                             [Rune Mehlsen](https://twitter.com/runemehlsen)                                              |                                             [Andreas Mehlsen](https://twitter.com/andreasmehlsen)                                              |                                 [You?](https://github.com/runem/lit-analyzer/blob/master/CONTRIBUTING.md)                                  |
+| [<img alt="Rune Mehlsen" src="https://avatars2.githubusercontent.com/u/5372940?s=460&v=4" width="100">](https://twitter.com/runemehlsen) | [<img alt="Andreas Mehlsen" src="https://avatars1.githubusercontent.com/u/6267397?s=460&v=4" width="100">](https://twitter.com/andreasmehlsen) | [<img alt="You?" src="https://joeschmoe.io/api/v1/random" width="100">](https://github.com/JackRobards/lit-analyzer/blob/master/CONTRIBUTING.md) |
+| :--------------------------------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------------------------: |
+|                                             [Rune Mehlsen](https://twitter.com/runemehlsen)                                              |                                             [Andreas Mehlsen](https://twitter.com/andreasmehlsen)                                              |                                 [You?](https://github.com/JackRobards/lit-analyzer/blob/master/CONTRIBUTING.md)                                  |
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png)](#license)
 

--- a/packages/lit-analyzer/package.json
+++ b/packages/lit-analyzer/package.json
@@ -96,7 +96,7 @@
 		"ts-simple-type": "~2.0.0-next.0",
 		"vscode-css-languageservice": "6.3.2",
 		"vscode-html-languageservice": "5.3.1",
-		"web-component-analyzer": "^2.0.0"
+		"web-component-analyzer-fork": "^2.0.0"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.2",

--- a/packages/lit-analyzer/package.json
+++ b/packages/lit-analyzer/package.json
@@ -1,12 +1,12 @@
 {
-	"name": "lit-analyzer",
+	"name": "lit-analyzer-fork",
 	"version": "2.0.3",
 	"description": "CLI that type checks bindings in lit-html templates",
 	"author": "runem",
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/runem/lit-analyzer.git"
+		"url": "https://github.com/JackRobards/lit-analyzer.git"
 	},
 	"keywords": [
 		"lit-html",
@@ -21,7 +21,7 @@
 		"template"
 	],
 	"bin": {
-		"lit-analyzer": "cli.js"
+		"lit-analyzer-fork": "cli.js"
 	},
 	"scripts": {
 		"build": "wireit",
@@ -135,7 +135,7 @@
 		{
 			"name": "You?",
 			"img": "https://joeschmoe.io/api/v1/random",
-			"url": "https://github.com/runem/lit-analyzer/blob/master/CONTRIBUTING.md"
+			"url": "https://github.com/JackRobards/lit-analyzer/blob/master/CONTRIBUTING.md"
 		}
 	]
 }

--- a/packages/lit-analyzer/readme.config.json
+++ b/packages/lit-analyzer/readme.config.json
@@ -1,7 +1,7 @@
 {
 	"line": "rainbow",
 	"ids": {
-		"github": "runem/lit-analyzer",
-		"npm": "lit-analyzer"
+		"github": "JackRobards/lit-analyzer",
+		"npm": "lit-analyzer-fork"
 	}
 }

--- a/packages/lit-analyzer/readme/config.md
+++ b/packages/lit-analyzer/readme/config.md
@@ -7,7 +7,7 @@ You can configure the CLI with arguments:
 lit-analyzer --strict --rules.no-unknown-tag-name off --format markdown
 ```
 
-**Note:** You can also configure the CLI using a `tsconfig.json` file (see [ts-lit-plugin](https://github.com/runem/lit-analyzer/blob/master/packages/ts-lit-plugin)).
+**Note:** You can also configure the CLI using a `tsconfig.json` file (see [ts-lit-plugin](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin)).
 
 ### Available arguments
 
@@ -15,7 +15,7 @@ lit-analyzer --strict --rules.no-unknown-tag-name off --format markdown
 | Option | Description | Type | Default |
 | :----- | ----------- | ---- | ------- |
 | `--help` | Print help message | `boolean` | |
-| `--rules.rule-name` | Enable or disable rules (example: --rules.no-unknown-tag-name off). Severity can be "off" \| "warn" \| "error". See a list of rules [here](https://github.com/runem/lit-analyzer/blob/master/docs/readme/rules.md). | `{"rule-name": "off" \| "warn" \| "error"}` |  |
+| `--rules.rule-name` | Enable or disable rules (example: --rules.no-unknown-tag-name off). Severity can be "off" \| "warn" \| "error". See a list of rules [here](https://github.com/JackRobards/lit-analyzer/blob/master/docs/readme/rules.md). | `{"rule-name": "off" \| "warn" \| "error"}` |  |
 | `--strict` | Enable strict mode. This changes the default ruleset | `boolean` | |
 | `--format` | Change the format of how diagnostics are reported | `code` \| `list` \| `markdown` | code |
 | `--maxWarnings` | Fail only when the number of warnings is larger than this number | `number` | -1 |

--- a/packages/lit-analyzer/readme/install.md
+++ b/packages/lit-analyzer/readme/install.md
@@ -8,4 +8,4 @@ npm install lit-analyzer -g
 **Note:**
 
 - If you use Visual Studio Code you can also install the [lit-plugin](https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin) extension.
-- If you use Typescript you can also install [ts-lit-plugin](https://github.com/runem/lit-analyzer/blob/master/packages/ts-lit-plugin).
+- If you use Typescript you can also install [ts-lit-plugin-fork](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin).

--- a/packages/lit-analyzer/src/lib/analyze/component-analyzer/component-analyzer.ts
+++ b/packages/lit-analyzer/src/lib/analyze/component-analyzer/component-analyzer.ts
@@ -1,4 +1,4 @@
-import { ComponentDeclaration, ComponentDefinition } from "web-component-analyzer";
+import { ComponentDeclaration, ComponentDefinition } from "web-component-analyzer-fork";
 import { LitAnalyzerContext } from "../lit-analyzer-context.js";
 import { ReportedRuleDiagnostic } from "../rule-collection.js";
 import { LitCodeFix } from "../types/lit-code-fix.js";

--- a/packages/lit-analyzer/src/lib/analyze/default-lit-analyzer-context.ts
+++ b/packages/lit-analyzer/src/lib/analyze/default-lit-analyzer-context.ts
@@ -1,7 +1,7 @@
 import * as tsMod from "typescript";
 import { HostCancellationToken, Program, SourceFile, TypeChecker } from "typescript";
 import * as tsServer from "typescript/lib/tsserverlibrary.js";
-import { analyzeHTMLElement, analyzeSourceFile } from "web-component-analyzer";
+import { analyzeHTMLElement, analyzeSourceFile } from "web-component-analyzer-fork";
 import { ALL_RULES } from "../rules/all-rules.js";
 import { MAX_RUNNING_TIME_PER_OPERATION } from "./constants.js";
 import { getBuiltInHtmlCollection } from "./data/get-built-in-html-collection.js";

--- a/packages/lit-analyzer/src/lib/analyze/parse/convert-component-definitions-to-html-collection.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/convert-component-definitions-to-html-collection.ts
@@ -1,6 +1,6 @@
 import { isSimpleType, SimpleType, SimpleTypeAny, toSimpleType } from "ts-simple-type";
 import { TypeChecker } from "typescript";
-import { AnalyzerResult, ComponentDeclaration, ComponentDefinition, ComponentFeatures } from "web-component-analyzer";
+import { AnalyzerResult, ComponentDeclaration, ComponentDefinition, ComponentFeatures } from "web-component-analyzer-fork";
 import { lazy } from "../util/general-util.js";
 import { HtmlDataCollection, HtmlDataFeatures, HtmlTag } from "./parse-html-data/html-tag.js";
 

--- a/packages/lit-analyzer/src/lib/analyze/parse/parse-dependencies/parse-dependencies.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/parse-dependencies/parse-dependencies.ts
@@ -1,5 +1,5 @@
 import { SourceFile } from "typescript";
-import { ComponentDefinition } from "web-component-analyzer";
+import { ComponentDefinition } from "web-component-analyzer-fork";
 import { LitAnalyzerContext } from "../../lit-analyzer-context.js";
 import { visitIndirectImportsFromSourceFile } from "./visit-dependencies.js";
 

--- a/packages/lit-analyzer/src/lib/analyze/parse/parse-html-data/html-tag.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/parse-html-data/html-tag.ts
@@ -1,5 +1,12 @@
 import { isAssignableToSimpleTypeKind, SimpleType, typeToString } from "ts-simple-type";
-import { ComponentCssPart, ComponentCssProperty, ComponentDeclaration, ComponentEvent, ComponentMember, ComponentSlot } from "web-component-analyzer";
+import {
+	ComponentCssPart,
+	ComponentCssProperty,
+	ComponentDeclaration,
+	ComponentEvent,
+	ComponentMember,
+	ComponentSlot
+} from "web-component-analyzer-fork";
 import {
 	LIT_HTML_BOOLEAN_ATTRIBUTE_MODIFIER,
 	LIT_HTML_EVENT_LISTENER_ATTRIBUTE_MODIFIER,

--- a/packages/lit-analyzer/src/lib/analyze/rule-collection.ts
+++ b/packages/lit-analyzer/src/lib/analyze/rule-collection.ts
@@ -1,4 +1,4 @@
-import { ComponentDeclaration, ComponentDefinition } from "web-component-analyzer";
+import { ComponentDeclaration, ComponentDefinition } from "web-component-analyzer-fork";
 import { isRuleEnabled, LitAnalyzerRuleId } from "./lit-analyzer-config.js";
 import { LitAnalyzerContext } from "./lit-analyzer-context.js";
 import { HtmlDocument } from "./parse/document/text-document/html-document/html-document.js";

--- a/packages/lit-analyzer/src/lib/analyze/store/analyzer-definition-store.ts
+++ b/packages/lit-analyzer/src/lib/analyze/store/analyzer-definition-store.ts
@@ -1,5 +1,5 @@
 import { SourceFile } from "typescript";
-import { AnalyzerResult, ComponentDeclaration, ComponentDefinition } from "web-component-analyzer";
+import { AnalyzerResult, ComponentDeclaration, ComponentDefinition } from "web-component-analyzer-fork";
 
 export interface AnalyzerDefinitionStore {
 	getAnalysisResultForFile(sourceFile: SourceFile): AnalyzerResult | undefined;

--- a/packages/lit-analyzer/src/lib/analyze/store/definition-store/default-analyzer-definition-store.ts
+++ b/packages/lit-analyzer/src/lib/analyze/store/definition-store/default-analyzer-definition-store.ts
@@ -1,5 +1,5 @@
 import { SourceFile } from "typescript";
-import { AnalyzerResult, ComponentDeclaration, ComponentDefinition, visitAllHeritageClauses } from "web-component-analyzer";
+import { AnalyzerResult, ComponentDeclaration, ComponentDefinition, visitAllHeritageClauses } from "web-component-analyzer-fork";
 import { getDeclarationsInFile } from "../../util/component-util.js";
 import { AnalyzerDefinitionStore } from "../analyzer-definition-store.js";
 

--- a/packages/lit-analyzer/src/lib/analyze/store/dependency-store/default-analyzer-dependency-store.ts
+++ b/packages/lit-analyzer/src/lib/analyze/store/dependency-store/default-analyzer-dependency-store.ts
@@ -1,5 +1,5 @@
 import { SourceFile } from "typescript";
-import { ComponentDefinition } from "web-component-analyzer";
+import { ComponentDefinition } from "web-component-analyzer-fork";
 import { AnalyzerDependencyStore } from "../analyzer-dependency-store.js";
 
 export class DefaultAnalyzerDependencyStore implements AnalyzerDependencyStore {

--- a/packages/lit-analyzer/src/lib/analyze/types/lit-rename-info.ts
+++ b/packages/lit-analyzer/src/lib/analyze/types/lit-rename-info.ts
@@ -1,4 +1,4 @@
-import { ComponentDefinition } from "web-component-analyzer";
+import { ComponentDefinition } from "web-component-analyzer-fork";
 import { HtmlDocument } from "../parse/document/text-document/html-document/html-document.js";
 import { HtmlNode } from "./html-node/html-node-types.js";
 import { LitTargetKind } from "./lit-target-kind.js";

--- a/packages/lit-analyzer/src/lib/analyze/types/rule/rule-module.ts
+++ b/packages/lit-analyzer/src/lib/analyze/types/rule/rule-module.ts
@@ -1,4 +1,4 @@
-import { ComponentDeclaration, ComponentDefinition, ComponentMember } from "web-component-analyzer";
+import { ComponentDeclaration, ComponentDefinition, ComponentMember } from "web-component-analyzer-fork";
 import { LitAnalyzerRuleId } from "../../lit-analyzer-config.js";
 import { HtmlNodeAttrAssignment } from "../html-node/html-node-attr-assignment-types.js";
 import { HtmlNodeAttr } from "../html-node/html-node-attr-types.js";

--- a/packages/lit-analyzer/src/lib/analyze/util/component-util.ts
+++ b/packages/lit-analyzer/src/lib/analyze/util/component-util.ts
@@ -1,5 +1,5 @@
 import { SourceFile } from "typescript";
-import { ComponentDeclaration, ComponentDefinition, visitAllHeritageClauses } from "web-component-analyzer";
+import { ComponentDeclaration, ComponentDefinition, visitAllHeritageClauses } from "web-component-analyzer-fork";
 
 export function getDeclarationsInFile(definition: ComponentDefinition, sourceFile: SourceFile): ComponentDeclaration[] {
 	const declarations = new Set<ComponentDeclaration>();

--- a/packages/lit-analyzer/src/lib/cli/compile.ts
+++ b/packages/lit-analyzer/src/lib/cli/compile.ts
@@ -108,7 +108,7 @@ export function resolveTsConfigCompilerOptions(): CompilerOptions | undefined {
 }
 
 /**
- * Resolves the nearest tsconfig.json and returns the configuration seed within the plugins section for "ts-lit-plugin"
+ * Resolves the nearest tsconfig.json and returns the configuration seed within the plugins section for "ts-lit-plugin-fork"
  */
 export function readLitAnalyzerConfigFromTsConfig(): Partial<LitAnalyzerConfig> | undefined {
 	const compilerOptions = resolveTsConfigCompilerOptions();
@@ -116,7 +116,7 @@ export function readLitAnalyzerConfigFromTsConfig(): Partial<LitAnalyzerConfig> 
 	// Finds the plugin section
 	if (compilerOptions != null && "plugins" in compilerOptions) {
 		const plugins = compilerOptions.plugins as ({ name: string } & Partial<LitAnalyzerConfig>)[];
-		const tsLitPluginOptions = plugins.find(plugin => plugin.name === "ts-lit-plugin");
+		const tsLitPluginOptions = plugins.find(plugin => plugin.name === "ts-lit-plugin-fork");
 		if (tsLitPluginOptions != null) {
 			return tsLitPluginOptions;
 		}

--- a/packages/lit-analyzer/src/lib/rules/no-incompatible-property-type.ts
+++ b/packages/lit-analyzer/src/lib/rules/no-incompatible-property-type.ts
@@ -1,6 +1,6 @@
 import { isAssignableToSimpleTypeKind, isSimpleType, SimpleType, SimpleTypeKind, toSimpleType, typeToString } from "ts-simple-type";
 import { Node } from "typescript";
-import { LitElementPropertyConfig } from "web-component-analyzer";
+import { LitElementPropertyConfig } from "web-component-analyzer-fork";
 import { RuleModule } from "../analyze/types/rule/rule-module.js";
 import { RuleModuleContext } from "../analyze/types/rule/rule-module-context.js";
 import { joinArray } from "../analyze/util/array-util.js";

--- a/packages/lit-analyzer/src/lib/rules/no-property-visibility-mismatch.ts
+++ b/packages/lit-analyzer/src/lib/rules/no-property-visibility-mismatch.ts
@@ -1,5 +1,5 @@
 import { Identifier, ObjectLiteralExpression } from "typescript";
-import { ComponentMember } from "web-component-analyzer";
+import { ComponentMember } from "web-component-analyzer-fork";
 import { RuleFixAction, RuleFixActionChangeRange } from "../analyze/types/rule/rule-fix-action.js";
 import { RuleModule } from "../analyze/types/rule/rule-module.js";
 import { RuleModuleContext } from "../analyze/types/rule/rule-module-context.js";

--- a/packages/ts-lit-plugin/README.md
+++ b/packages/ts-lit-plugin/README.md
@@ -1,4 +1,4 @@
-<!-- ⚠️ This README has been generated from the file(s) "readme.blueprint.md" ⚠️--><h1 align="center">ts-lit-plugin</h1>
+<!-- ⚠️ This README has been generated from the file(s) "readme.blueprint.md" ⚠️--><h1 align="center">ts-lit-plugin-fork</h1>
 <p align="center">
   <b>Typescript plugin that adds type checking and code completion to lit-html</b></br>
   <sub><sub>
@@ -7,10 +7,10 @@
 <br />
 
 <p align="center">
-		<a href="https://npmcharts.com/compare/ts-lit-plugin?minimal=true"><img alt="Downloads per month" src="https://img.shields.io/npm/dm/ts-lit-plugin.svg" height="20"/></a>
-<a href="https://www.npmjs.com/package/ts-lit-plugin"><img alt="NPM Version" src="https://img.shields.io/npm/v/ts-lit-plugin.svg" height="20"/></a>
-<a href="https://david-dm.org/runem/lit-analyzer"><img alt="Dependencies" src="https://img.shields.io/david/runem/lit-analyzer.svg" height="20"/></a>
-<a href="https://github.com/runem/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/runem/lit-analyzer.svg" height="20"/></a>
+		<a href="https://npmcharts.com/compare/ts-lit-plugin-fork?minimal=true"><img alt="Downloads per month" src="https://img.shields.io/npm/dm/ts-lit-plugin-fork.svg" height="20"/></a>
+<a href="https://www.npmjs.com/package/ts-lit-plugin-fork"><img alt="NPM Version" src="https://img.shields.io/npm/v/ts-lit-plugin-fork.svg" height="20"/></a>
+<a href="https://david-dm.org/JackRobards/lit-analyzer"><img alt="Dependencies" src="https://img.shields.io/david/JackRobards/lit-analyzer.svg" height="20"/></a>
+<a href="https://github.com/JackRobards/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/JackRobards/lit-analyzer.svg" height="20"/></a>
 	</p>
 
 <p align="center">
@@ -25,7 +25,7 @@ First, install the plugin:
 
 <!-- prettier-ignore -->
 ```bash
-npm install ts-lit-plugin -D
+npm install ts-lit-plugin-fork -D
 ```
 
 Then add a `plugins` section to your [`tsconfig.json`](http://www.typescriptlang.org/docs/handbook/tsconfig-json.html):
@@ -36,14 +36,14 @@ Then add a `plugins` section to your [`tsconfig.json`](http://www.typescriptlang
   "compilerOptions": {
     "plugins": [
       {
-        "name": "ts-lit-plugin"
+        "name": "ts-lit-plugin-fork"
       }
     ]
   }
 }
 ```
 
-Finally, restart you Typescript Language Service, and you should start getting diagnostics from `ts-lit-plugin`.
+Finally, restart you Typescript Language Service, and you should start getting diagnostics from `ts-lit-plugin-fork`.
 
 **Note:**
 
@@ -64,7 +64,7 @@ You can configure this plugin through your `tsconfig.json`.
   "compilerOptions": {
     "plugins": [
       {
-        "name": "ts-lit-plugin",
+        "name": "ts-lit-plugin-fork",
         "strict": true,
         "rules": {
           "no-unknown-tag-name": "off",

--- a/packages/ts-lit-plugin/README.md
+++ b/packages/ts-lit-plugin/README.md
@@ -48,7 +48,7 @@ Finally, restart you Typescript Language Service, and you should start getting d
 **Note:**
 
 - If you use Visual Studio Code you can also install the [lit-plugin](https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin) extension.
-- If you would rather use a CLI, you can install the [lit-analyzer](https://github.com/runem/lit-analyzer/blob/master/packages/lit-analyzer).
+- If you would rather use a CLI, you can install the [lit-analyzer](https://github.com/JackRobards/lit-analyzer/blob/master/packages/lit-analyzer).
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png)](#configuration)
 
@@ -81,7 +81,7 @@ You can configure this plugin through your `tsconfig.json`.
 <!-- prettier-ignore -->
 | Option | Description | Type | Default |
 | :----- | ----------- | ---- | ------- |
-| `strict` | Enabling strict mode will change which rules are applied as default (see list of [rules](https://github.com/runem/lit-analyzer/blob/master/docs/readme/rules.md)) | `boolean` | false |
+| `strict` | Enabling strict mode will change which rules are applied as default (see list of [rules](https://github.com/JackRobards/lit-analyzer/blob/master/docs/readme/rules.md)) | `boolean` | false |
 | `rules` | Enable/disable individual rules or set their severity. Example: `{"no-unknown-tag-name": "off"}` | `{"rule-name": "off" \| "warn" \| "error"}` | The default rules enabled depend on the `strict` option |
 | `disable` | Completely disable this plugin. | `boolean` | false |
 | `dontShowSuggestions` | This option sets strict as  | `boolean` | false |
@@ -156,7 +156,7 @@ Each rule can have severity of `off`, `warning` or `error`. You can toggle rules
 
 ### Validating custom elements
 
-All web components in your code are analyzed using [web-component-analyzer](https://github.com/runem/web-component-analyzer) which supports native custom elements and web components built with LitElement.
+All web components in your code are analyzed using [web-component-analyzer](https://github.com/JackRobards/lit-analyzer/tree/master/packages/web-component-analyzer) which supports native custom elements and web components built with LitElement.
 
 #### 🤷‍ no-unknown-tag-name
 
@@ -252,7 +252,7 @@ declare global {
 
 ### Validating binding names
 
-Attributes, properties and events are picked up on custom elements using [web-component-analyzer](https://github.com/runem/web-component-analyzer) which supports native custom elements and web components built with LitElement.
+Attributes, properties and events are picked up on custom elements using [web-component-analyzer](https://github.com/JackRobards/lit-analyzer/tree/master/packages/web-component-analyzer) which supports native custom elements and web components built with LitElement.
 
 #### ✅ no-unknown-attribute, no-unknown-property
 
@@ -712,7 +712,7 @@ css`
 
 ## ➤ Documenting slots, events, attributes and properties
 
-Code is analyzed using [web-component-analyzer](https://github.com/runem/web-component-analyzer) in order to find properties, attributes and events. Unfortunately, sometimes it's not possible to analyze these things by looking at the code, and you will have to document how your component looks using `jsdoc`like this:
+Code is analyzed using [web-component-analyzer](https://github.com/JackRobards/lit-analyzer/tree/master/packages/web-component-analyzer) in order to find properties, attributes and events. Unfortunately, sometimes it's not possible to analyze these things by looking at the code, and you will have to document how your component looks using `jsdoc`like this:
 
 <!-- prettier-ignore -->
 ```js
@@ -740,9 +740,9 @@ customElements.define("my-element", MyElement);
 
 ## ➤ Contributors
 
-| [<img alt="Rune Mehlsen" src="https://avatars2.githubusercontent.com/u/5372940?s=460&v=4" width="100">](https://twitter.com/runemehlsen) | [<img alt="Andreas Mehlsen" src="https://avatars1.githubusercontent.com/u/6267397?s=460&v=4" width="100">](https://twitter.com/andreasmehlsen) | [<img alt="You?" src="https://joeschmoe.io/api/v1/random" width="100">](https://github.com/runem/lit-analyzer/blob/master/CONTRIBUTING.md) |
-| :--------------------------------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------------------: |
-|                                             [Rune Mehlsen](https://twitter.com/runemehlsen)                                              |                                             [Andreas Mehlsen](https://twitter.com/andreasmehlsen)                                              |                                 [You?](https://github.com/runem/lit-analyzer/blob/master/CONTRIBUTING.md)                                  |
+| [<img alt="Rune Mehlsen" src="https://avatars2.githubusercontent.com/u/5372940?s=460&v=4" width="100">](https://twitter.com/runemehlsen) | [<img alt="Andreas Mehlsen" src="https://avatars1.githubusercontent.com/u/6267397?s=460&v=4" width="100">](https://twitter.com/andreasmehlsen) | [<img alt="You?" src="https://joeschmoe.io/api/v1/random" width="100">](https://github.com/JackRobards/lit-analyzer/blob/master/CONTRIBUTING.md) |
+| :--------------------------------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------------------------: |
+|                                             [Rune Mehlsen](https://twitter.com/runemehlsen)                                              |                                             [Andreas Mehlsen](https://twitter.com/andreasmehlsen)                                              |                                 [You?](https://github.com/JackRobards/lit-analyzer/blob/master/CONTRIBUTING.md)                                  |
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png)](#license)
 

--- a/packages/ts-lit-plugin/package.json
+++ b/packages/ts-lit-plugin/package.json
@@ -55,7 +55,7 @@
 	],
 	"dependencies": {
 		"lit-analyzer-fork": "^2.0.1",
-		"web-component-analyzer": "^2.0.0"
+		"web-component-analyzer-fork": "^2.0.0"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.2",

--- a/packages/ts-lit-plugin/package.json
+++ b/packages/ts-lit-plugin/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "ts-lit-plugin",
+	"name": "ts-lit-plugin-fork",
 	"version": "2.0.2",
-	"description": "Typescript plugin that adds type checking and code completion to lit-html",
+	"description": "Typescript plugin that adds type checking and code completion to lit-html. Fork of the original ts-lit-plugin.",
 	"author": "JackRobards",
 	"license": "MIT",
 	"repository": {

--- a/packages/ts-lit-plugin/package.json
+++ b/packages/ts-lit-plugin/package.json
@@ -2,11 +2,11 @@
 	"name": "ts-lit-plugin",
 	"version": "2.0.2",
 	"description": "Typescript plugin that adds type checking and code completion to lit-html",
-	"author": "runem",
+	"author": "JackRobards",
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/runem/lit-analyzer.git"
+		"url": "https://github.com/JackRobards/lit-analyzer.git"
 	},
 	"keywords": [
 		"lit-html",
@@ -54,7 +54,7 @@
 		"/html-documentation/"
 	],
 	"dependencies": {
-		"lit-analyzer": "^2.0.1",
+		"lit-analyzer-fork": "^2.0.1",
 		"web-component-analyzer": "^2.0.0"
 	},
 	"devDependencies": {
@@ -77,7 +77,7 @@
 		{
 			"name": "You?",
 			"img": "https://joeschmoe.io/api/v1/random",
-			"url": "https://github.com/runem/lit-analyzer/blob/master/CONTRIBUTING.md"
+			"url": "https://github.com/JackRobards/lit-analyzer/blob/master/CONTRIBUTING.md"
 		}
 	]
 }

--- a/packages/ts-lit-plugin/readme.config.json
+++ b/packages/ts-lit-plugin/readme.config.json
@@ -2,6 +2,6 @@
 	"line": "rainbow",
 	"ids": {
 		"github": "JackRobards/lit-analyzer",
-		"npm": "ts-lit-plugin"
+		"npm": "ts-lit-plugin-fork"
 	}
 }

--- a/packages/ts-lit-plugin/readme.config.json
+++ b/packages/ts-lit-plugin/readme.config.json
@@ -1,7 +1,7 @@
 {
 	"line": "rainbow",
 	"ids": {
-		"github": "runem/lit-analyzer",
+		"github": "JackRobards/lit-analyzer",
 		"npm": "ts-lit-plugin"
 	}
 }

--- a/packages/ts-lit-plugin/readme/config.md
+++ b/packages/ts-lit-plugin/readme/config.md
@@ -10,7 +10,7 @@ You can configure this plugin through your `tsconfig.json`.
   "compilerOptions": {
     "plugins": [
       {
-        "name": "ts-lit-plugin",
+        "name": "ts-lit-plugin-fork",
         "strict": true,
         "rules": {
           "no-unknown-tag-name": "off",

--- a/packages/ts-lit-plugin/readme/install.md
+++ b/packages/ts-lit-plugin/readme/install.md
@@ -4,7 +4,7 @@ First, install the plugin:
 
 <!-- prettier-ignore -->
 ```bash
-npm install ts-lit-plugin -D
+npm install ts-lit-plugin-fork -D
 ```
 
 Then add a `plugins` section to your [`tsconfig.json`](http://www.typescriptlang.org/docs/handbook/tsconfig-json.html):
@@ -15,16 +15,16 @@ Then add a `plugins` section to your [`tsconfig.json`](http://www.typescriptlang
   "compilerOptions": {
     "plugins": [
       {
-        "name": "ts-lit-plugin"
+        "name": "ts-lit-plugin-fork"
       }
     ]
   }
 }
 ```
 
-Finally, restart you Typescript Language Service, and you should start getting diagnostics from `ts-lit-plugin`.
+Finally, restart you Typescript Language Service, and you should start getting diagnostics from `ts-lit-plugin-fork`.
 
 **Note:**
 
 - If you use Visual Studio Code you can also install the [lit-plugin](https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin) extension.
-- If you would rather use a CLI, you can install the [lit-analyzer](https://github.com/runem/lit-analyzer/blob/master/packages/lit-analyzer).
+- If you would rather use a CLI, you can install the [lit-analyzer](https://github.com/JackRobards/lit-analyzer/blob/master/packages/lit-analyzer).

--- a/packages/ts-lit-plugin/src/bazel-plugin.ts
+++ b/packages/ts-lit-plugin/src/bazel-plugin.ts
@@ -1,4 +1,4 @@
-import { DefaultLitAnalyzerContext, LitAnalyzer, LitAnalyzerConfig, LitAnalyzerContext, makeConfig } from "lit-analyzer";
+import { DefaultLitAnalyzerContext, LitAnalyzer, LitAnalyzerConfig, LitAnalyzerContext, makeConfig } from "lit-analyzer-fork";
 import ts, { Diagnostic } from "typescript";
 import { translateDiagnostics } from "./ts-lit-plugin/translate/translate-diagnostics.js";
 

--- a/packages/ts-lit-plugin/src/index.ts
+++ b/packages/ts-lit-plugin/src/index.ts
@@ -3,7 +3,7 @@ import { LitAnalyzerConfig, LitAnalyzerLoggerLevel, makeConfig, VERSION } from "
 import * as ts from "typescript";
 import { CompilerOptions } from "typescript";
 import * as tsServer from "typescript/lib/tsserverlibrary.js";
-import { VERSION as WCA_VERSION } from "web-component-analyzer";
+import { VERSION as WCA_VERSION } from "web-component-analyzer-fork";
 import { decorateLanguageService } from "./decorate-language-service.js";
 import { logger } from "./logger.js";
 import { LitPluginContext } from "./ts-lit-plugin/lit-plugin-context.js";

--- a/packages/ts-lit-plugin/src/index.ts
+++ b/packages/ts-lit-plugin/src/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { LitAnalyzerConfig, LitAnalyzerLoggerLevel, makeConfig, VERSION } from "lit-analyzer";
+import { LitAnalyzerConfig, LitAnalyzerLoggerLevel, makeConfig, VERSION } from "lit-analyzer-fork";
 import * as ts from "typescript";
 import { CompilerOptions } from "typescript";
 import * as tsServer from "typescript/lib/tsserverlibrary.js";

--- a/packages/ts-lit-plugin/src/index.ts
+++ b/packages/ts-lit-plugin/src/index.ts
@@ -61,7 +61,7 @@ export function init({ typescript }: { typescript: typeof ts }): tsServer.server
 
 				context.updateConfig(makeConfig(info.config));
 
-				logger.verbose("Starting ts-lit-plugin...");
+				logger.verbose("Starting ts-lit-plugin-fork...");
 
 				if (printDebugOnce != null) printDebugOnce();
 
@@ -74,7 +74,7 @@ export function init({ typescript }: { typescript: typeof ts }): tsServer.server
 
 				return decoratedService;
 			} catch (e) {
-				logger.error("ts-lit-plugin crashed while decorating the language service...", e);
+				logger.error("ts-lit-plugin-fork crashed while decorating the language service...", e);
 
 				return info.languageService;
 			}
@@ -110,13 +110,13 @@ export function init({ typescript }: { typescript: typeof ts }): tsServer.server
 }
 
 /**
- * Resolves the nearest tsconfig.json and returns the configuration seed within the plugins section for "ts-lit-plugin"
+ * Resolves the nearest tsconfig.json and returns the configuration seed within the plugins section for "ts-lit-plugin-fork"
  */
 function readLitAnalyzerConfigFromCompilerOptions(compilerOptions: CompilerOptions): Partial<LitAnalyzerConfig> | undefined {
 	// Finds the plugin section
 	if ("plugins" in compilerOptions) {
 		const plugins = compilerOptions.plugins as ({ name: string } & Partial<LitAnalyzerConfig>)[];
-		const tsLitPluginOptions = plugins.find(plugin => plugin.name === "ts-lit-plugin");
+		const tsLitPluginOptions = plugins.find(plugin => plugin.name === "ts-lit-plugin-fork");
 		if (tsLitPluginOptions != null) {
 			return tsLitPluginOptions;
 		}

--- a/packages/ts-lit-plugin/src/logger.ts
+++ b/packages/ts-lit-plugin/src/logger.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { appendFileSync, writeFileSync } from "fs";
-import { DefaultLitAnalyzerLogger, LitAnalyzerLoggerLevel } from "lit-analyzer";
+import { DefaultLitAnalyzerLogger, LitAnalyzerLoggerLevel } from "lit-analyzer-fork";
 import { join } from "path";
 import { inspect } from "util";
 import * as tsServer from "typescript/lib/tsserverlibrary.js";

--- a/packages/ts-lit-plugin/src/logger.ts
+++ b/packages/ts-lit-plugin/src/logger.ts
@@ -91,7 +91,10 @@ export class Logger extends DefaultLitAnalyzerLogger {
 			} catch {
 				// ignore
 			}
-			this.tsLogger?.msg(`[ts-lit-plugin] ${message}`, level === LitAnalyzerLoggerLevel.ERROR ? tsServer.server.Msg.Err : tsServer.server.Msg.Info);
+			this.tsLogger?.msg(
+				`[ts-lit-plugin-fork] ${message}`,
+				level === LitAnalyzerLoggerLevel.ERROR ? tsServer.server.Msg.Err : tsServer.server.Msg.Info
+			);
 		}
 	}
 

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/lit-plugin-context.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/lit-plugin-context.ts
@@ -1,4 +1,4 @@
-import { DefaultLitAnalyzerContext, LitAnalyzerConfig } from "lit-analyzer";
+import { DefaultLitAnalyzerContext, LitAnalyzerConfig } from "lit-analyzer-fork";
 import { logger } from "../logger.js";
 
 export class LitPluginContext extends DefaultLitAnalyzerContext {

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-code-fixes.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-code-fixes.ts
@@ -1,4 +1,4 @@
-import { LitCodeFix, LitCodeFixAction } from "lit-analyzer";
+import { LitCodeFix, LitCodeFixAction } from "lit-analyzer-fork";
 import { CodeFixAction, FileTextChanges, SourceFile } from "typescript";
 import { translateRange } from "./translate-range.js";
 

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-completion-details.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-completion-details.ts
@@ -1,4 +1,4 @@
-import { LitCompletionDetails } from "lit-analyzer";
+import { LitCompletionDetails } from "lit-analyzer-fork";
 import { CompletionEntryDetails } from "typescript";
 import { LitPluginContext } from "../lit-plugin-context.js";
 

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-completions.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-completions.ts
@@ -1,4 +1,4 @@
-import { LitCompletion } from "lit-analyzer";
+import { LitCompletion } from "lit-analyzer-fork";
 import { CompletionEntry, CompletionInfo } from "typescript";
 import { translateRange } from "./translate-range.js";
 import { translateTargetKind } from "./translate-target-kind.js";

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-definition.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-definition.ts
@@ -1,4 +1,4 @@
-import { LitDefinition, LitDefinitionTarget } from "lit-analyzer";
+import { LitDefinition, LitDefinitionTarget } from "lit-analyzer-fork";
 import { DefinitionInfo, DefinitionInfoAndBoundSpan } from "typescript";
 import { tsModule } from "../../ts-module.js";
 import { translateRange } from "./translate-range.js";

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-diagnostics.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-diagnostics.ts
@@ -1,4 +1,4 @@
-import { LitAnalyzerContext, LitDiagnostic } from "lit-analyzer";
+import { LitAnalyzerContext, LitDiagnostic } from "lit-analyzer-fork";
 import { DiagnosticMessageChain, DiagnosticWithLocation, SourceFile } from "typescript";
 import { translateRange } from "./translate-range.js";
 

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-format-edits.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-format-edits.ts
@@ -1,4 +1,4 @@
-import { LitFormatEdit } from "lit-analyzer";
+import { LitFormatEdit } from "lit-analyzer-fork";
 import * as ts from "typescript";
 import { translateRange } from "./translate-range.js";
 

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-outlining-spans.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-outlining-spans.ts
@@ -1,4 +1,4 @@
-import { LitOutliningSpan } from "lit-analyzer";
+import { LitOutliningSpan } from "lit-analyzer-fork";
 import { translateRange } from "./translate-range.js";
 import type * as ts from "typescript";
 

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-quick-info.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-quick-info.ts
@@ -1,4 +1,4 @@
-import { LitQuickInfo } from "lit-analyzer";
+import { LitQuickInfo } from "lit-analyzer-fork";
 import { QuickInfo } from "typescript";
 import { tsModule } from "../../ts-module.js";
 import { translateRange } from "./translate-range.js";

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-range.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-range.ts
@@ -1,4 +1,4 @@
-import { Range } from "lit-analyzer";
+import { Range } from "lit-analyzer-fork";
 import { TextSpan } from "typescript";
 
 export function translateRange(range: Range): TextSpan {

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-rename-info.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-rename-info.ts
@@ -1,4 +1,4 @@
-import { LitRenameInfo } from "lit-analyzer";
+import { LitRenameInfo } from "lit-analyzer-fork";
 import { RenameInfo } from "typescript";
 import { translateTargetKind } from "./translate-target-kind.js";
 import { translateRange } from "./translate-range.js";

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-rename-locations.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-rename-locations.ts
@@ -1,4 +1,4 @@
-import { LitRenameLocation } from "lit-analyzer";
+import { LitRenameLocation } from "lit-analyzer-fork";
 import { translateRange } from "./translate-range.js";
 import { RenameLocation } from "typescript";
 

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-target-kind.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-target-kind.ts
@@ -1,4 +1,4 @@
-import { LitTargetKind } from "lit-analyzer";
+import { LitTargetKind } from "lit-analyzer-fork";
 import { ScriptElementKind } from "typescript";
 import { tsModule } from "../../ts-module.js";
 

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/ts-lit-plugin.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/ts-lit-plugin.ts
@@ -1,4 +1,4 @@
-import { LitAnalyzer } from "lit-analyzer";
+import { LitAnalyzer } from "lit-analyzer-fork";
 import {
 	CodeFixAction,
 	CompletionEntryDetails,

--- a/packages/vscode-lit-plugin/README.md
+++ b/packages/vscode-lit-plugin/README.md
@@ -15,8 +15,8 @@
 [![](https://vsmarketplacebadges.dev/downloads-short/runem.lit-plugin.svg)](https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin)
 [![](https://vsmarketplacebadges.dev/rating-short/runem.lit-plugin.svg)](https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin)
 <a href="https://opensource.org/licenses/MIT"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-green.svg" height="20"></img></a>
-<a href="https://david-dm.org/runem/lit-analyzer"><img alt="Dependencies" src="https://img.shields.io/david/runem/lit-analyzer.svg?color=green" height="20"/></a>
-<a href="https://github.com/runem/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/runem/lit-analyzer.svg" height="20"/></a>
+<a href="https://david-dm.org/JackRobards/lit-analyzer"><img alt="Dependencies" src="https://img.shields.io/david/JackRobards/lit-analyzer.svg?color=green" height="20"/></a>
+<a href="https://github.com/JackRobards/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/JackRobards/lit-analyzer.svg" height="20"/></a>
 
   <img src="https://user-images.githubusercontent.com/5372940/62078476-02c1ec00-b24d-11e9-8de5-1322012cbde2.gif" alt="Lit plugin GIF"/>
 
@@ -92,7 +92,7 @@ Each rule can have severity of `off`, `warning` or `error`. You can toggle rules
 
 ### Validating custom elements
 
-All web components in your code are analyzed using [web-component-analyzer](https://github.com/runem/web-component-analyzer) which supports native custom elements and web components built with LitElement.
+All web components in your code are analyzed using [web-component-analyzer](https://github.com/JackRobards/lit-analyzer/tree/master/packages/web-component-analyzer) which supports native custom elements and web components built with LitElement.
 
 #### 🤷‍ no-unknown-tag-name
 
@@ -188,7 +188,7 @@ declare global {
 
 ### Validating binding names
 
-Attributes, properties and events are picked up on custom elements using [web-component-analyzer](https://github.com/runem/web-component-analyzer) which supports native custom elements and web components built with LitElement.
+Attributes, properties and events are picked up on custom elements using [web-component-analyzer](https://github.com/JackRobards/lit-analyzer/tree/master/packages/web-component-analyzer) which supports native custom elements and web components built with LitElement.
 
 #### ✅ no-unknown-attribute, no-unknown-property
 
@@ -696,7 +696,7 @@ When typing html inside a template tag `lit-plugin` auto-closes tags as you woul
 
 ### 🔍 Automatically finds custom elements
 
-If you define a custom element somewhere in your code `lit-plugin` will automatically find it. Then it will provide auto-import functionality, type checking and code completion out of the box by analyzing the element. [web-component-analyzer](https://github.com/runem/web-component-analyzer) is the tool that takes care of analyzing components.
+If you define a custom element somewhere in your code `lit-plugin` will automatically find it. Then it will provide auto-import functionality, type checking and code completion out of the box by analyzing the element. [web-component-analyzer](https://github.com/JackRobards/lit-analyzer/tree/master/packages/web-component-analyzer) is the tool that takes care of analyzing components.
 
 ### 🌎 Support for dependencies that extend the global HTMLElementTagNameMap
 
@@ -724,7 +724,7 @@ This plugin already supports [custom vscode html data format](https://code.visua
 
 ## ➤ Documenting slots, events, attributes and properties
 
-Code is analyzed using [web-component-analyzer](https://github.com/runem/web-component-analyzer) in order to find properties, attributes and events. Unfortunately, sometimes it's not possible to analyze these things by looking at the code, and you will have to document how your component looks using `jsdoc`like this:
+Code is analyzed using [web-component-analyzer](https://github.com/JackRobards/lit-analyzer/tree/master/packages/web-component-analyzer) in order to find properties, attributes and events. Unfortunately, sometimes it's not possible to analyze these things by looking at the code, and you will have to document how your component looks using `jsdoc`like this:
 
 <!-- prettier-ignore -->
 ```js
@@ -757,7 +757,7 @@ This plugin is similar to [vscode-lit-html](https://github.com/mjbvz/vscode-lit-
 Below is a comparison table of the two plugins:
 
 <!-- prettier-ignore -->
-| Feature                 | [vscode-lit-html](https://github.com/mjbvz/vscode-lit-html)   | [vscode-lit-plugin](https://github.com/runem/vscode-lit-plugin) |
+| Feature                 | [vscode-lit-html](https://github.com/mjbvz/vscode-lit-html)   | [vscode-lit-plugin](https://github.com/JackRobards/vscode-lit-plugin) |
 |-------------------------|------------|------------|
 | CSS support             | ❌         | ✅         |
 | Goto definition         | ❌         | ✅         |
@@ -795,9 +795,9 @@ This library couples it all together and synchronizes relevant settings between 
 
 ## ➤ Contributors
 
-| [<img alt="Rune Mehlsen" src="https://avatars2.githubusercontent.com/u/5372940?s=460&v=4" width="100">](https://twitter.com/runemehlsen) | [<img alt="Andreas Mehlsen" src="https://avatars1.githubusercontent.com/u/6267397?s=460&v=4" width="100">](https://twitter.com/andreasmehlsen) | [<img alt="You?" src="https://joeschmoe.io/api/v1/random" width="100">](https://github.com/runem/lit-analyzer/blob/master/CONTRIBUTING.md) |
-| :--------------------------------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------------------: |
-|                                             [Rune Mehlsen](https://twitter.com/runemehlsen)                                              |                                             [Andreas Mehlsen](https://twitter.com/andreasmehlsen)                                              |                                 [You?](https://github.com/runem/lit-analyzer/blob/master/CONTRIBUTING.md)                                  |
+| [<img alt="Rune Mehlsen" src="https://avatars2.githubusercontent.com/u/5372940?s=460&v=4" width="100">](https://twitter.com/runemehlsen) | [<img alt="Andreas Mehlsen" src="https://avatars1.githubusercontent.com/u/6267397?s=460&v=4" width="100">](https://twitter.com/andreasmehlsen) | [<img alt="You?" src="https://joeschmoe.io/api/v1/random" width="100">](https://github.com/JackRobards/lit-analyzer/blob/master/CONTRIBUTING.md) |
+| :--------------------------------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------------------------: |
+|                                             [Rune Mehlsen](https://twitter.com/runemehlsen)                                              |                                             [Andreas Mehlsen](https://twitter.com/andreasmehlsen)                                              |                                 [You?](https://github.com/JackRobards/lit-analyzer/blob/master/CONTRIBUTING.md)                                  |
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png)](#license)
 

--- a/packages/vscode-lit-plugin/README.md
+++ b/packages/vscode-lit-plugin/README.md
@@ -650,14 +650,14 @@ css`
 
 You can configure this plugin by going to `VS Code Settings` > `Extension` > `lit-plugin`.
 
-**Note:** You can also configure the plugin using a `tsconfig.json` file (see [ts-lit-plugin](https://github.com/runem/lit-analyzer/blob/master/packages/ts-lit-plugin)).
+**Note:** You can also configure the plugin using a `tsconfig.json` file (see [ts-lit-plugin](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin)).
 
 ### Available options
 
 <!-- prettier-ignore -->
 | Option | Description | Type | Default |
 | :----- | ----------- | ---- | ------- |
-| `strict` | Enabling strict mode will change which rules are applied as default (see list of [rules](https://github.com/runem/lit-analyzer/blob/master/docs/readme/rules.md)) | `boolean` | false |
+| `strict` | Enabling strict mode will change which rules are applied as default (see list of [rules](https://github.com/JackRobards/lit-analyzer/blob/master/docs/readme/rules.md)) | `boolean` | false |
 | `rules` | Enable/disable individual rules or set their severity. Example: `{"no-unknown-tag-name": "off"}` | `{"rule-name": "off" \| "warn" \| "error"}` | The default rules enabled depend on the `strict` option |
 | `disable` | Completely disable this plugin. | `boolean` | false |
 | `dontShowSuggestions` | This option sets strict as  | `boolean` | false |
@@ -785,7 +785,7 @@ Below is a comparison table of the two plugins:
 
 All features are provided by these three libraries:
 
-- **[ts-lit-plugin](https://github.com/runem/lit-analyzer)**: The typescript plugin that powers the logic through the typescript language service (code completion, type checking, eg.). Therefore issues regarding anything but syntax highlighting should be opened in `ts-lit-plugin` and not `vscode-lit-plugin`.
+- **[ts-lit-plugin](https://github.com/JackRobards/lit-analyzer)**: The typescript plugin that powers the logic through the typescript language service (code completion, type checking, eg.). Therefore issues regarding anything but syntax highlighting should be opened in `ts-lit-plugin` and not `vscode-lit-plugin`.
 - **[vscode-lit-html](https://github.com/mjbvz/vscode-lit-html)**: Provides highlighting for the html template tag.
 - **[vscode-styled-components](https://github.com/styled-components/vscode-styled-components)**: Provides highlighting for the css template tag.
 

--- a/packages/vscode-lit-plugin/copy-to-built.js
+++ b/packages/vscode-lit-plugin/copy-to-built.js
@@ -25,7 +25,7 @@ async function main() {
 	// We're only using the bundled version, so the plugin doesn't need any
 	// dependencies.
 	tsPluginPackageJson.dependencies = {};
-	await writeFile("./built/node_modules/ts-lit-plugin/package.json", JSON.stringify(tsPluginPackageJson, null, 2));
+	await writeFile("./built/node_modules/ts-lit-plugin-fork/package.json", JSON.stringify(tsPluginPackageJson, null, 2));
 	await copy("../ts-lit-plugin/index.js", "./built/node_modules/ts-lit-plugin-fork/index.js");
 
 	const pluginPackageJson = require("./package.json");

--- a/packages/vscode-lit-plugin/copy-to-built.js
+++ b/packages/vscode-lit-plugin/copy-to-built.js
@@ -20,19 +20,19 @@ async function main() {
 
 	// For the TS compiler plugin, it must be in node modules because that's
 	// hard coded by the TS compiler's custom module resolution logic.
-	await mkdirp("./built/node_modules/ts-lit-plugin");
+	await mkdirp("./built/node_modules/ts-lit-plugin-fork");
 	const tsPluginPackageJson = require("../ts-lit-plugin/package.json");
 	// We're only using the bundled version, so the plugin doesn't need any
 	// dependencies.
 	tsPluginPackageJson.dependencies = {};
 	await writeFile("./built/node_modules/ts-lit-plugin/package.json", JSON.stringify(tsPluginPackageJson, null, 2));
-	await copy("../ts-lit-plugin/index.js", "./built/node_modules/ts-lit-plugin/index.js");
+	await copy("../ts-lit-plugin/index.js", "./built/node_modules/ts-lit-plugin-fork/index.js");
 
 	const pluginPackageJson = require("./package.json");
 	// vsce is _very_ picky about the directories in node_modules matching the
-	// extension's package.json, so we need an entry for ts-lit-plugin or it
+	// extension's package.json, so we need an entry for ts-lit-plugin-fork or it
 	// will think that it's extraneous.
-	pluginPackageJson.dependencies["ts-lit-plugin"] = "*";
+	pluginPackageJson.dependencies["ts-lit-plugin-fork"] = "*";
 	await writeFile("./built/package.json", JSON.stringify(pluginPackageJson, null, 2));
 
 	// Copy static files used by the extension.

--- a/packages/vscode-lit-plugin/esbuild.script.mjs
+++ b/packages/vscode-lit-plugin/esbuild.script.mjs
@@ -1,27 +1,27 @@
 import * as esbuild from "esbuild";
 
 await esbuild.build({
-  entryPoints: ["src/extension.ts"],
-  bundle: true,
-  outfile: "built/bundle.js",
-  platform: "node",
-  minify: true,
-  target: "es2017",
-  format: "cjs",
-  color: true,
-  external: ["vscode", "typescript"],
-  mainFields: ["module", "main"]
+	entryPoints: ["src/extension.ts"],
+	bundle: true,
+	outfile: "built/bundle.js",
+	platform: "node",
+	minify: true,
+	target: "es2017",
+	format: "cjs",
+	color: true,
+	external: ["vscode", "typescript"],
+	mainFields: ["module", "main"]
 });
 
 await esbuild.build({
-  entryPoints: ["../ts-lit-plugin/src/index.ts"],
-  bundle: true,
-  outfile: "built/node_modules/ts-lit-plugin/lib/index.js",
-  platform: "node",
-  external: ["typescript"],
-  minify: true,
-  target: "es2017",
-  format: "cjs",
-  color: true,
-  mainFields: ["module", "main"]
+	entryPoints: ["../ts-lit-plugin/src/index.ts"],
+	bundle: true,
+	outfile: "built/node_modules/ts-lit-plugin-fork/lib/index.js",
+	platform: "node",
+	external: ["typescript"],
+	minify: true,
+	target: "es2017",
+	format: "cjs",
+	color: true,
+	mainFields: ["module", "main"]
 });

--- a/packages/vscode-lit-plugin/package.json
+++ b/packages/vscode-lit-plugin/package.json
@@ -131,7 +131,7 @@
 			],
 			"output": [
 				"built/bundle.js",
-				"built/node_modules/ts-lit-plugin/index.js"
+				"built/node_modules/ts-lit-plugin-fork/index.js"
 			]
 		},
 		"make-built-dir": {
@@ -152,8 +152,8 @@
 			"output": [
 				"built/docs",
 				"built/node_modules/typescript",
-				"built/node_modules/ts-lit-plugin/package.json",
-				"built/node_modules/ts-lit-plugin/index.js",
+				"built/node_modules/ts-lit-plugin-fork/package.json",
+				"built/node_modules/ts-lit-plugin-fork/index.js",
 				"built/schemas",
 				"built/syntaxes",
 				"built/LICENSE.md",
@@ -751,7 +751,7 @@
 		],
 		"typescriptServerPlugins": [
 			{
-				"name": "ts-lit-plugin",
+				"name": "ts-lit-plugin-fork",
 				"enableForWorkspaceTypeScriptVersions": true
 			}
 		],

--- a/packages/vscode-lit-plugin/package.json
+++ b/packages/vscode-lit-plugin/package.json
@@ -4,7 +4,7 @@
 	"displayName": "lit-plugin",
 	"description": "Syntax highlighting, type checking and code completion for lit-html",
 	"version": "1.4.3",
-	"publisher": "JackRobards",
+	"publisher": "runem",
 	"icon": "docs/assets/lit-plugin@256w.png",
 	"license": "MIT",
 	"engines": {

--- a/packages/vscode-lit-plugin/package.json
+++ b/packages/vscode-lit-plugin/package.json
@@ -4,7 +4,7 @@
 	"displayName": "lit-plugin",
 	"description": "Syntax highlighting, type checking and code completion for lit-html",
 	"version": "1.4.3",
-	"publisher": "runem",
+	"publisher": "JackRobards",
 	"icon": "docs/assets/lit-plugin@256w.png",
 	"license": "MIT",
 	"engines": {
@@ -13,14 +13,14 @@
 	"categories": [
 		"Programming Languages"
 	],
-	"homepage": "https://github.com/runem/lit-analyzer",
+	"homepage": "https://github.com/JackRobards/lit-analyzer",
 	"bugs": {
-		"url": "https://github.com/runem/lit-analyzer/issues",
+		"url": "https://github.com/JackRobards/lit-analyzer/issues",
 		"email": "runemehlsen@gmail.com"
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/runem/lit-analyzer.git"
+		"url": "https://github.com/JackRobards/lit-analyzer.git"
 	},
 	"main": "bundle.js",
 	"scripts": {
@@ -173,7 +173,7 @@
 		"@vscode/vsce": "^3.2.1",
 		"esbuild": "^0.24.2",
 		"fast-glob": "^3.2.11",
-		"lit-analyzer": "^2.0.3",
+		"lit-analyzer-fork": "^2.0.3",
 		"mocha": "^11.0.1",
 		"wireit": "^0.1.1"
 	},
@@ -198,7 +198,7 @@
 		{
 			"name": "You?",
 			"img": "https://joeschmoe.io/api/v1/random",
-			"url": "https://github.com/runem/lit-analyzer/blob/master/CONTRIBUTING.md"
+			"url": "https://github.com/JackRobards/lit-analyzer/blob/master/CONTRIBUTING.md"
 		}
 	],
 	"contributes": {

--- a/packages/vscode-lit-plugin/readme/config.md
+++ b/packages/vscode-lit-plugin/readme/config.md
@@ -2,7 +2,7 @@
 
 You can configure this plugin by going to `VS Code Settings` > `Extension` > `lit-plugin`.
 
-**Note:** You can also configure the plugin using a `tsconfig.json` file (see [ts-lit-plugin](https://github.com/runem/lit-analyzer/blob/master/packages/ts-lit-plugin)).
+**Note:** You can also configure the plugin using a `tsconfig.json` file (see [ts-lit-plugin](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin)).
 
 ### Available options
 

--- a/packages/vscode-lit-plugin/readme/feature-comparison.md
+++ b/packages/vscode-lit-plugin/readme/feature-comparison.md
@@ -5,7 +5,7 @@ This plugin is similar to [vscode-lit-html](https://github.com/mjbvz/vscode-lit-
 Below is a comparison table of the two plugins:
 
 <!-- prettier-ignore -->
-| Feature                 | [vscode-lit-html](https://github.com/mjbvz/vscode-lit-html)   | [vscode-lit-plugin](https://github.com/runem/vscode-lit-plugin) |
+| Feature                 | [vscode-lit-html](https://github.com/mjbvz/vscode-lit-html)   | [vscode-lit-plugin](https://github.com/JackRobards/vscode-lit-plugin) |
 |-------------------------|------------|------------|
 | CSS support             | ❌         | ✅         |
 | Goto definition         | ❌         | ✅         |

--- a/packages/vscode-lit-plugin/readme/header.md
+++ b/packages/vscode-lit-plugin/readme/header.md
@@ -8,8 +8,8 @@
 [![](https://vsmarketplacebadges.dev/downloads-short/runem.lit-plugin.svg)](https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin)
 [![](https://vsmarketplacebadges.dev/rating-short/runem.lit-plugin.svg)](https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin)
 <a href="https://opensource.org/licenses/MIT"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-green.svg" height="20"></img></a>
-<a href="https://david-dm.org/runem/lit-analyzer"><img alt="Dependencies" src="https://img.shields.io/david/runem/lit-analyzer.svg?color=green" height="20"/></a>
-<a href="https://github.com/runem/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/runem/lit-analyzer.svg" height="20"/></a>
+<a href="https://david-dm.org/JackRobards/lit-analyzer"><img alt="Dependencies" src="https://img.shields.io/david/JackRobards/lit-analyzer.svg?color=green" height="20"/></a>
+<a href="https://github.com/JackRobards/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/JackRobards/lit-analyzer.svg" height="20"/></a>
 
   <img src="https://user-images.githubusercontent.com/5372940/62078476-02c1ec00-b24d-11e9-8de5-1322012cbde2.gif" alt="Lit plugin GIF"/>
 

--- a/packages/vscode-lit-plugin/readme/how.md
+++ b/packages/vscode-lit-plugin/readme/how.md
@@ -2,7 +2,7 @@
 
 All features are provided by these three libraries:
 
-- **[ts-lit-plugin](https://github.com/runem/lit-analyzer)**: The typescript plugin that powers the logic through the typescript language service (code completion, type checking, eg.). Therefore issues regarding anything but syntax highlighting should be opened in `ts-lit-plugin` and not `vscode-lit-plugin`.
+- **[ts-lit-plugin](https://github.com/JackRobards/lit-analyzer)**: The typescript plugin that powers the logic through the typescript language service (code completion, type checking, eg.). Therefore issues regarding anything but syntax highlighting should be opened in `ts-lit-plugin` and not `vscode-lit-plugin`.
 - **[vscode-lit-html](https://github.com/mjbvz/vscode-lit-html)**: Provides highlighting for the html template tag.
 - **[vscode-styled-components](https://github.com/styled-components/vscode-styled-components)**: Provides highlighting for the css template tag.
 

--- a/packages/vscode-lit-plugin/readme/other.md
+++ b/packages/vscode-lit-plugin/readme/other.md
@@ -22,7 +22,7 @@ When typing html inside a template tag `lit-plugin` auto-closes tags as you woul
 
 ### 🔍 Automatically finds custom elements
 
-If you define a custom element somewhere in your code `lit-plugin` will automatically find it. Then it will provide auto-import functionality, type checking and code completion out of the box by analyzing the element. [web-component-analyzer](https://github.com/JackRobards/web-component-analyzer) is the tool that takes care of analyzing components.
+If you define a custom element somewhere in your code `lit-plugin` will automatically find it. Then it will provide auto-import functionality, type checking and code completion out of the box by analyzing the element. [web-component-analyzer](https://github.com/JackRobards/lit-analyzer/tree/master/packages/web-component-analyzer) is the tool that takes care of analyzing components.
 
 ### 🌎 Support for dependencies that extend the global HTMLElementTagNameMap
 

--- a/packages/vscode-lit-plugin/readme/other.md
+++ b/packages/vscode-lit-plugin/readme/other.md
@@ -22,7 +22,7 @@ When typing html inside a template tag `lit-plugin` auto-closes tags as you woul
 
 ### 🔍 Automatically finds custom elements
 
-If you define a custom element somewhere in your code `lit-plugin` will automatically find it. Then it will provide auto-import functionality, type checking and code completion out of the box by analyzing the element. [web-component-analyzer](https://github.com/runem/web-component-analyzer) is the tool that takes care of analyzing components.
+If you define a custom element somewhere in your code `lit-plugin` will automatically find it. Then it will provide auto-import functionality, type checking and code completion out of the box by analyzing the element. [web-component-analyzer](https://github.com/JackRobards/web-component-analyzer) is the tool that takes care of analyzing components.
 
 ### 🌎 Support for dependencies that extend the global HTMLElementTagNameMap
 

--- a/packages/vscode-lit-plugin/schemas/tsconfig.schema.json
+++ b/packages/vscode-lit-plugin/schemas/tsconfig.schema.json
@@ -12,7 +12,7 @@
 						"if": {
 							"properties": {
 								"name": {
-									"enum": ["ts-lit-plugin"]
+									"enum": ["ts-lit-plugin-fork"]
 								}
 							},
 							"required": ["name"]

--- a/packages/vscode-lit-plugin/src/extension.ts
+++ b/packages/vscode-lit-plugin/src/extension.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import { ColorProvider } from "./color-provider.js";
 import * as vscode from "vscode";
 
-const tsLitPluginId = "ts-lit-plugin";
+const tsLitPluginId = "ts-lit-plugin-fork";
 const typeScriptExtensionId = "vscode.typescript-language-features";
 const configurationSection = "lit-plugin";
 const configurationExperimentalHtmlSection = "html.experimental";

--- a/packages/vscode-lit-plugin/src/extension.ts
+++ b/packages/vscode-lit-plugin/src/extension.ts
@@ -1,4 +1,4 @@
-import { ALL_RULE_IDS, LitAnalyzerConfig } from "lit-analyzer";
+import { ALL_RULE_IDS, LitAnalyzerConfig } from "lit-analyzer-fork";
 import { join } from "path";
 import { ColorProvider } from "./color-provider.js";
 import * as vscode from "vscode";
@@ -211,7 +211,7 @@ function handleAnalyzeCommand() {
 			defaultAnalyzeGlob = glob;
 
 			const cliCommand = `npx lit-analyzer "${glob}"`;
-			const terminal = vscode.window.createTerminal("lit-analyzer");
+			const terminal = vscode.window.createTerminal("lit-analyzer-fork");
 			terminal.sendText(cliCommand, true);
 			terminal.show(true);
 		});

--- a/packages/web-component-analyzer/README.md
+++ b/packages/web-component-analyzer/README.md
@@ -1,17 +1,17 @@
 <h1 align="center">web-component-analyzer</h1>
 
 <p align="center">
-	<a href="https://npmcharts.com/compare/web-component-analyzer?minimal=true"><img alt="Downloads per month" src="https://img.shields.io/npm/dm/web-component-analyzer.svg" height="20"/></a>
-	<a href="https://www.npmjs.com/package/web-component-analyzer"><img alt="NPM Version" src="https://img.shields.io/npm/v/web-component-analyzer.svg" height="20"/></a>
-	<a href="https://david-dm.org/runem/web-component-analyzer"><img alt="Dependencies" src="https://img.shields.io/david/runem/web-component-analyzer.svg" height="20"/></a>
-	<a href="https://github.com/runem/web-component-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/runem/web-component-analyzer.svg" height="20"/></a>
+	<a href="https://npmcharts.com/compare/web-component-analyzer-fork?minimal=true"><img alt="Downloads per month" src="https://img.shields.io/npm/dm/web-component-analyzer-fork.svg" height="20"/></a>
+	<a href="https://www.npmjs.com/package/web-component-analyzer-fork"><img alt="NPM Version" src="https://img.shields.io/npm/v/web-component-analyzer-fork.svg" height="20"/></a>
+	<a href="https://david-dm.org/JackRobards/lit-analyzer"><img alt="Dependencies" src="https://img.shields.io/david/JackRobards/lit-analyzer.svg" height="20"/></a>
+	<a href="https://github.com/JackRobards/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/JackRobards/lit-analyzer.svg" height="20"/></a>
 </p>
 
 <p align="center">
   <img src="https://user-images.githubusercontent.com/5372940/68087781-1044ce80-fe59-11e9-969c-4234f9287f1b.gif" alt="Web component analyzer GIF"/>
 </p>
 
-`web-component-analyzer` is a CLI that makes it possible to easily analyze web components. It analyzes your code and jsdoc in order to extract `properties`, `attributes`, `methods`, `events`, `slots`, `css shadow parts` and `css custom properties`. Works with both javascript and typescript.
+`web-component-analyzer-fork` is a CLI that makes it possible to easily analyze web components. It analyzes your code and jsdoc in order to extract `properties`, `attributes`, `methods`, `events`, `slots`, `css shadow parts` and `css custom properties`. Works with both javascript and typescript.
 
 Try the online playground [here](https://runem.github.io/web-component-analyzer/)
 
@@ -21,7 +21,7 @@ In addition to [vanilla web components](https://developer.mozilla.org/en-US/docs
 - [polymer](https://github.com/Polymer/polymer)
 - [stencil](https://github.com/ionic-team/stencil) (partial)
 - [lwc](https://github.com/salesforce/lwc)
-- [open an issue for library requests](https://github.com/runem/web-component-analyzer/issues)
+- [open an issue for library requests](https://github.com/JackRobards/lit-analyzer/issues)
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#installation)
 
@@ -29,14 +29,14 @@ In addition to [vanilla web components](https://developer.mozilla.org/en-US/docs
 
 <!-- prettier-ignore -->
 ```bash
-$ npm install -g web-component-analyzer
+$ npm install -g web-component-analyzer-fork
 ```
 
 **or**
 
 <!-- prettier-ignore -->
 ```bash
-$ npx web-component-analyzer src
+$ npx web-component-analyzer-fork src
 ```
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#usage)
@@ -191,7 +191,7 @@ class MyElement extends HTMLElement {
 
 This tool extract information about your components by looking at your code directly and by looking at your JSDoc comments.
 
-**Code**: Web Component Analyzer supports multiple libraries. [Click here](https://github.com/runem/web-component-analyzer/blob/master/ANALYZE.md) for an overview of how each library is analyzed.
+**Code**: Web Component Analyzer supports multiple libraries. [Click here](https://github.com/JackRobards/web-component-analyzer/blob/master/ANALYZE.md) for an overview of how each library is analyzed.
 
 **JSDoc**: Read next section to learn more about how JSDoc is analyzed.
 
@@ -203,7 +203,7 @@ You can also directly use the underlying functionality of this tool if you don't
 
 <!-- prettier-ignore -->
 ```typescript
-import { analyzeSourceFile } from "web-component-analyzer";
+import { analyzeSourceFile } from "web-component-analyzer-fork";
 
 const result = analyzeSourceFile(sourceFile, { checker });
 ```
@@ -212,7 +212,7 @@ const result = analyzeSourceFile(sourceFile, { checker });
 
 <!-- prettier-ignore -->
 ```javascript
-import { analyzeText } from "web-component-analyzer";
+import { analyzeText } from "web-component-analyzer-fork";
 
 const code = `class MyElement extends HTMLElement {
 
@@ -236,7 +236,7 @@ const { results, program } = analyzeText([
 
 <!-- prettier-ignore -->
 ```javascript
-import { transformAnalyzerResult } from "web-component-analyzer";
+import { transformAnalyzerResult } from "web-component-analyzer-fork";
 
 const result = // the result of analyzing the component using one of the above functions
 

--- a/packages/web-component-analyzer/package.json
+++ b/packages/web-component-analyzer/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "web-component-analyzer",
+	"name": "web-component-analyzer-fork",
 	"version": "2.0.0",
 	"description": "CLI that analyzes web components",
 	"main": "lib/cjs/api.js",
@@ -71,7 +71,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/JackRobards/web-component-analyzer.git"
+		"url": "git+https://github.com/JackRobards/lit-analyzer.git"
 	},
 	"keywords": [
 		"web components",
@@ -133,6 +133,6 @@
 	},
 	"bin": {
 		"wca": "cli.js",
-		"web-component-analyzer": "cli.js"
+		"web-component-analyzer-fork": "cli.js"
 	}
 }

--- a/packages/web-component-analyzer/package.json
+++ b/packages/web-component-analyzer/package.json
@@ -71,7 +71,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/runem/web-component-analyzer.git"
+		"url": "git+https://github.com/JackRobards/web-component-analyzer.git"
 	},
 	"keywords": [
 		"web components",
@@ -88,9 +88,9 @@
 	"author": "Rune Mehlsen",
 	"license": "MIT",
 	"bugs": {
-		"url": "https://github.com/runem/web-component-analyzer/issues"
+		"url": "https://github.com/JackRobards/lit-analyzer/issues"
 	},
-	"homepage": "https://github.com/runem/web-component-analyzer#readme",
+	"homepage": "https://github.com/JackRobards/lit-analyzer#readme",
 	"dependencies": {
 		"fast-glob": "^3.2.2",
 		"ts-simple-type": "2.0.0-next.0",

--- a/readme.blueprint.md
+++ b/readme.blueprint.md
@@ -13,7 +13,7 @@ This mono-repository consists of the following tools:
 
 ## Rules
 
-You can find a list of all rules [here](https://github.com/runem/lit-analyzer/blob/master/docs/readme/rules.md).
+You can find a list of all rules [here](https://github.com/JackRobards/lit-analyzer/blob/master/docs/readme/rules.md).
 
 ## Contributing
 

--- a/readme.config.json
+++ b/readme.config.json
@@ -8,17 +8,17 @@
 		},
 		{
 			"alt": "Downloads per Month",
-			"img": "https://img.shields.io/npm/dm/lit-analyzer.svg?label=lit-analyzer",
-			"url": "https://www.npmjs.com/package/lit-analyzer"
+			"img": "https://img.shields.io/npm/dm/lit-analyzer-fork.svg?label=lit-analyzer-fork",
+			"url": "https://www.npmjs.com/package/lit-analyzer-fork"
 		},
 		{
 			"alt": "Downloads per Month",
-			"img": "https://img.shields.io/npm/dm/ts-lit-plugin.svg?label=ts-lit-plugin",
-			"url": "https://www.npmjs.com/package/ts-lit-plugin"
+			"img": "https://img.shields.io/npm/dm/ts-lit-plugin-fork.svg?label=ts-lit-plugin-fork",
+			"url": "https://www.npmjs.com/package/ts-lit-plugin-fork"
 		},
 		{
 			"alt": "Contributors",
-			"img": "https://img.shields.io/github/contributors/JackRobards/lit-analyzer",
+			"img": "https://img.shields.io/github/contributors/JackRobards/lit-analyzer-fork",
 			"url": "https://github.com/JackRobards/lit-analyzer/graphs/contributors"
 		}
 	]

--- a/readme.config.json
+++ b/readme.config.json
@@ -18,8 +18,8 @@
 		},
 		{
 			"alt": "Contributors",
-			"img": "https://img.shields.io/github/contributors/runem/lit-analyzer",
-			"url": "https://github.com/runem/lit-analyzer/graphs/contributors"
+			"img": "https://img.shields.io/github/contributors/JackRobards/lit-analyzer",
+			"url": "https://github.com/JackRobards/lit-analyzer/graphs/contributors"
 		}
 	]
 }


### PR DESCRIPTION
So that we can publish the new versions to npm, we will need to rename the packages. The VSCode extension will get a new name in a future PR.

I'm not 100% certain all of the Markdown files are fully updated correctly, but there are quite a lot of them to sift through. Always can update those in the future as they noticed though!