### PR TITLE
Fix readme commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<!-- ⚠️ This README has been generated from the file(s) "readme.blueprint.md" ⚠️--><h1 align="center">lit-analyzer</h1>
+<!-- ⚠️ This README has been generated from the file(s) "readme.blueprint.md" ⚠️--><h1 align="center">lit-analyzer-fork</h1>
 <p align="center">
-  <b>Monorepo for tools that analyze lit-html templates</b></br>
+  <b>Monorepo for tools that analyze lit-html templates. Updated fork of the original lit-analyzer.</b></br>
   <sub><sub>
 </p>
 
@@ -10,7 +10,7 @@
 		<a href="https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin"><img alt="Downloads per Month" src="https://vsmarketplacebadges.dev/downloads-short/runem.lit-plugin.svg?label=vscode-lit-plugin" height="20"/></a>
 <a href="https://www.npmjs.com/package/lit-analyzer-fork"><img alt="Downloads per Month" src="https://img.shields.io/npm/dm/lit-analyzer-fork.svg?label=lit-analyzer-fork" height="20"/></a>
 <a href="https://www.npmjs.com/package/ts-lit-plugin-fork"><img alt="Downloads per Month" src="https://img.shields.io/npm/dm/ts-lit-plugin-fork.svg?label=ts-lit-plugin-fork" height="20"/></a>
-<a href="https://github.com/JackRobards/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/JackRobards/lit-analyzer" height="20"/></a>
+<a href="https://github.com/JackRobards/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/JackRobards/lit-analyzer-fork" height="20"/></a>
 	</p>
 
 This mono-repository consists of the following tools:

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	],
 	"scripts": {
 		"prettier:write": "prettier --write \"packages/*/src/**/*.ts\"",
-		"readme": "npx @appnest/readme generate -i readme.blueprint.md -c readme.config.json",
+		"readme": "wireit",
 		"dev": "cd dev && TSS_DEBUG=5999 code . --disable-extension runem.lit-plugin",
 		"dev:logs": "touch dev/lit-plugin.log && tail -f dev/lit-plugin.log",
 		"lint": "wireit",
@@ -109,6 +109,14 @@
 			"dependencies": [
 				"./packages/vscode-lit-plugin:package"
 			]
+		},
+		"readme": {
+			"dependencies": [
+				"./packages/lit-analyzer:readme",
+				"./packages/ts-lit-plugin:readme",
+				"./packages/vscode-lit-plugin:readme"
+			],
+			"command": "npx @appnest/readme generate -i readme.blueprint.md -c readme.config.json"
 		}
 	},
 	"devDependencies": {

--- a/packages/lit-analyzer/README.md
+++ b/packages/lit-analyzer/README.md
@@ -1,4 +1,4 @@
-<!-- ⚠️ This README has been generated from the file(s) "readme.blueprint.md" ⚠️--><h1 align="center">lit-analyzer</h1>
+<!-- ⚠️ This README has been generated from the file(s) "readme.blueprint.md" ⚠️--><h1 align="center">lit-analyzer-fork</h1>
 <p align="center">
   <b>CLI that type checks bindings in lit-html templates</b></br>
   <sub><sub>

--- a/packages/lit-analyzer/package.json
+++ b/packages/lit-analyzer/package.json
@@ -26,7 +26,7 @@
 	"scripts": {
 		"build": "wireit",
 		"prepublishOnly": "npm test",
-		"readme": "readme generate -i readme.blueprint.md -c readme.config.json",
+		"readme": "npx @appnest/readme generate -i readme.blueprint.md -c readme.config.json",
 		"eslint": "eslint src",
 		"test": "wireit",
 		"test:ava": "wireit",

--- a/packages/lit-analyzer/readme/config.md
+++ b/packages/lit-analyzer/readme/config.md
@@ -7,7 +7,7 @@ You can configure the CLI with arguments:
 lit-analyzer --strict --rules.no-unknown-tag-name off --format markdown
 ```
 
-**Note:** You can also configure the CLI using a `tsconfig.json` file (see [ts-lit-plugin](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin)).
+**Note:** You can also configure the CLI using a `tsconfig.json` file (see [ts-lit-plugin-fork](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin)).
 
 ### Available arguments
 

--- a/packages/ts-lit-plugin/README.md
+++ b/packages/ts-lit-plugin/README.md
@@ -1,6 +1,6 @@
 <!-- ⚠️ This README has been generated from the file(s) "readme.blueprint.md" ⚠️--><h1 align="center">ts-lit-plugin-fork</h1>
 <p align="center">
-  <b>Typescript plugin that adds type checking and code completion to lit-html</b></br>
+  <b>Typescript plugin that adds type checking and code completion to lit-html. Fork of the original ts-lit-plugin.</b></br>
   <sub><sub>
 </p>
 

--- a/packages/ts-lit-plugin/package.json
+++ b/packages/ts-lit-plugin/package.json
@@ -25,7 +25,7 @@
 		"build": "wireit",
 		"eslint": "eslint src",
 		"test": "wireit",
-		"readme": "readme generate -i readme.blueprint.md -c readme.config.json"
+		"readme": "npx @appnest/readme generate -i readme.blueprint.md -c readme.config.json"
 	},
 	"wireit": {
 		"build": {

--- a/packages/vscode-lit-plugin/README.md
+++ b/packages/vscode-lit-plugin/README.md
@@ -650,7 +650,7 @@ css`
 
 You can configure this plugin by going to `VS Code Settings` > `Extension` > `lit-plugin`.
 
-**Note:** You can also configure the plugin using a `tsconfig.json` file (see [ts-lit-plugin](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin)).
+**Note:** You can also configure the plugin using a `tsconfig.json` file (see [ts-lit-plugin-fork](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin)).
 
 ### Available options
 
@@ -785,7 +785,7 @@ Below is a comparison table of the two plugins:
 
 All features are provided by these three libraries:
 
-- **[ts-lit-plugin](https://github.com/JackRobards/lit-analyzer)**: The typescript plugin that powers the logic through the typescript language service (code completion, type checking, eg.). Therefore issues regarding anything but syntax highlighting should be opened in `ts-lit-plugin` and not `vscode-lit-plugin`.
+- **[ts-lit-plugin-fork](https://github.com/JackRobards/lit-analyzer)**: The typescript plugin that powers the logic through the typescript language service (code completion, type checking, eg.). Therefore issues regarding anything but syntax highlighting should be opened in `ts-lit-plugin` and not `vscode-lit-plugin`.
 - **[vscode-lit-html](https://github.com/mjbvz/vscode-lit-html)**: Provides highlighting for the html template tag.
 - **[vscode-styled-components](https://github.com/styled-components/vscode-styled-components)**: Provides highlighting for the css template tag.
 

--- a/packages/vscode-lit-plugin/package.json
+++ b/packages/vscode-lit-plugin/package.json
@@ -26,7 +26,7 @@
 	"scripts": {
 		"watch": "tsc -watch -p ./",
 		"package": "wireit",
-		"readme": "readme generate -i readme.blueprint.md -c readme.config.json",
+		"readme": "npx @appnest/readme generate -i readme.blueprint.md -c readme.config.json",
 		"test": "wireit",
 		"build": "wireit",
 		"eslint": "eslint src",

--- a/packages/vscode-lit-plugin/readme/config.md
+++ b/packages/vscode-lit-plugin/readme/config.md
@@ -2,7 +2,7 @@
 
 You can configure this plugin by going to `VS Code Settings` > `Extension` > `lit-plugin`.
 
-**Note:** You can also configure the plugin using a `tsconfig.json` file (see [ts-lit-plugin](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin)).
+**Note:** You can also configure the plugin using a `tsconfig.json` file (see [ts-lit-plugin-fork](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin)).
 
 ### Available options
 

--- a/packages/vscode-lit-plugin/readme/how.md
+++ b/packages/vscode-lit-plugin/readme/how.md
@@ -2,7 +2,7 @@
 
 All features are provided by these three libraries:
 
-- **[ts-lit-plugin](https://github.com/JackRobards/lit-analyzer)**: The typescript plugin that powers the logic through the typescript language service (code completion, type checking, eg.). Therefore issues regarding anything but syntax highlighting should be opened in `ts-lit-plugin` and not `vscode-lit-plugin`.
+- **[ts-lit-plugin-fork](https://github.com/JackRobards/lit-analyzer)**: The typescript plugin that powers the logic through the typescript language service (code completion, type checking, eg.). Therefore issues regarding anything but syntax highlighting should be opened in `ts-lit-plugin` and not `vscode-lit-plugin`.
 - **[vscode-lit-html](https://github.com/mjbvz/vscode-lit-html)**: Provides highlighting for the html template tag.
 - **[vscode-styled-components](https://github.com/styled-components/vscode-styled-components)**: Provides highlighting for the css template tag.
 


### PR DESCRIPTION
These commands are still configured to use [@appnest/readme](https://www.npmjs.com/package/@appnest/readme). The package was removed as a direct dependency from the monorepo since it is no longer maintained, but as long as the config files still exist then this change will keep the commands working as it did previously until an alternative to the configs can be considered.