### PR TITLE
Return type hint information if it is available

### DIFF
--- a/.changeset/eighty-pianos-cross.md
+++ b/.changeset/eighty-pianos-cross.md
@@ -1,0 +1,5 @@
+---
+"lit-analyzer-fork": patch
+---
+
+Return type hint information if it is available for html-tag

--- a/packages/lit-analyzer/src/lib/analyze/parse/parse-html-data/html-tag.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/parse-html-data/html-tag.ts
@@ -230,6 +230,9 @@ export function targetKindAndTypeText(target: HtmlAttrTarget, options: Descripti
 	const prefix = `(${targetKindText(target)}) ${options.modifier || ""}${target.name}`;
 
 	if (isAssignableToSimpleTypeKind(target.getType(), "ANY")) {
+		if (target.declaration?.typeHint) {
+			return `${prefix}: ${target.declaration.typeHint}`;
+		}
 		return `${prefix}`;
 	}
 


### PR DESCRIPTION
"The webcomponent analyzer returns a typehint string we can display that if it is present and there isn't any simpletype information"

Not a change I made, it is taken from this PR:
https://github.com/runem/lit-analyzer/pull/357

Thank you to the original author!