### PR TITLE
Expand support of no-missing-element-type-definition rule

### DIFF
--- a/.changeset/chilled-planets-hug.md
+++ b/.changeset/chilled-planets-hug.md
@@ -1,0 +1,6 @@
+---
+"web-component-analyzer-fork": minor
+"lit-analyzer-fork": minor
+---
+
+Support tag names which are static class properties or variables with no-missing-element-type-definition rule"

--- a/packages/lit-analyzer/src/test/rules/no-missing-element-type-definition.ts
+++ b/packages/lit-analyzer/src/test/rules/no-missing-element-type-definition.ts
@@ -16,7 +16,7 @@ tsTest("'no-missing-element-type-definition' reports diagnostic when element is 
 	hasDiagnostic(t, diagnostics, "no-missing-element-type-definition");
 });
 
-tsTest("'no-missing-element-type-definition' reports no diagnostic when element is not in HTMLElementTagNameMap", t => {
+tsTest("'no-missing-element-type-definition' reports no diagnostic when element is in HTMLElementTagNameMap", t => {
 	const { diagnostics } = getDiagnostics(
 		`
 		class MyElement extends HTMLElement { }; 
@@ -24,6 +24,48 @@ tsTest("'no-missing-element-type-definition' reports no diagnostic when element 
 		declare global {
 			interface HTMLElementTagNameMap {
 				"my-element": MyElement
+			}
+		}
+	`,
+		{
+			rules: { "no-missing-element-type-definition": true }
+		}
+	);
+
+	hasNoDiagnostics(t, diagnostics);
+});
+
+tsTest("'no-missing-element-type-definition' reports no diagnostic when element is in HTMLElementTagNameMap using class property", t => {
+	const { diagnostics } = getDiagnostics(
+		`
+		class MyElement extends HTMLElement { 
+			static readonly TAG_NAME = "my-element"
+		}; 
+		customElements.define(MyElement.TAG_NAME, MyElement)
+		declare global {
+			interface HTMLElementTagNameMap {
+				[MyElement.TAG_NAME]: MyElement
+			}
+		}
+	`,
+		{
+			rules: { "no-missing-element-type-definition": true }
+		}
+	);
+
+	hasNoDiagnostics(t, diagnostics);
+});
+
+tsTest("'no-missing-element-type-definition' reports no diagnostic when element is in HTMLElementTagNameMap variable", t => {
+	const { diagnostics } = getDiagnostics(
+		`
+		const TAG_NAME = "my-element"
+		class MyElement extends HTMLElement { 
+		}; 
+		customElements.define(MyElement.TAG_NAME, MyElement)
+		declare global {
+			interface HTMLElementTagNameMap {
+				[TAG_NAME]: MyElement
 			}
 		}
 	`,

--- a/packages/web-component-analyzer/src/analyze/util/ast-util.ts
+++ b/packages/web-component-analyzer/src/analyze/util/ast-util.ts
@@ -97,11 +97,16 @@ export function getInterfaceKeys(
 				continue;
 			}
 
+			let keyNode = resolvedKey.node;
 			let identifier: Node | undefined;
 			let declaration: Node | undefined;
 			if (ts.isTypeReferenceNode(member.type)) {
 				// { ____: MyButton; } or { ____: namespace.MyButton; }
 				identifier = member.type.typeName;
+				if (ts.isComputedPropertyName(member.name)) {
+					// e.g. [MyButton.TAG] : MyButton -> use initial member name node instead of resolved node
+					keyNode = member.name.expression;
+				}
 			} else if (ts.isTypeLiteralNode(member.type)) {
 				identifier = undefined;
 				declaration = member.type;
@@ -110,7 +115,7 @@ export function getInterfaceKeys(
 			}
 
 			if (declaration != null || identifier != null) {
-				extensions.push({ key: String(resolvedKey.value), keyNode: resolvedKey.node, declaration, identifier });
+				extensions.push({ key: String(resolvedKey.value), keyNode, declaration, identifier });
 			}
 		}
 	}

--- a/packages/web-component-analyzer/src/analyze/util/resolve-node-value.ts
+++ b/packages/web-component-analyzer/src/analyze/util/resolve-node-value.ts
@@ -77,12 +77,14 @@ export function resolveNodeValue(node: Node | undefined, context: Context): { va
 		return resolveNodeValue(node.expression, { ...context, depth });
 	}
 
-	// Resolve initializer value of enum members.
-	else if (ts.isEnumMember(node)) {
+	// Resolve initializer value of enum members or class properties.
+	else if (ts.isEnumMember(node) || ts.isPropertyDeclaration(node)) {
 		if (node.initializer != null) {
 			return resolveNodeValue(node.initializer, { ...context, depth });
-		} else {
+		} else if (node.parent.name) {
 			return { value: `${node.parent.name.text}.${node.name.getText()}`, node };
+		} else {
+			return { value: `${node.name.getText()}`, node };
 		}
 	}
 


### PR DESCRIPTION
The idea is to make sure this change supports both static class properties, and also variables

> Tag name is correctly resolved if tag name is a static class property.
> When "discovering" custom element definitions in HTMLElementTagNameMap, where the tag name is a static class property, the node holding the property is resolved. As such lit-analyzer no-missing-element-type-definition rule behaves correctly

Not a change I made, it is taken from these two PRs:
https://github.com/runem/web-component-analyzer/pull/279
https://github.com/runem/lit-analyzer/pull/331

Thank you to the original author!

I added a test for the variable case, which I am hoping to also solve in this PR.