### PR TITLE
Simplify no-unclosed-tag rule

### DIFF
--- a/.changeset/wise-grapes-applaud.md
+++ b/.changeset/wise-grapes-applaud.md
@@ -1,0 +1,5 @@
+---
+"lit-analyzer-fork": patch
+---
+
+Rework no-unclosed-tag rule to improve to cleanly check for begining and ending tags

--- a/packages/lit-analyzer/src/lib/analyze/parse/document/text-document/html-document/parse-html-node/parse-html-node.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/document/text-document/html-document/parse-html-node/parse-html-node.ts
@@ -51,7 +51,6 @@ export function parseHtmlNode(p5Node: IP5TagNode, parent: HtmlNode | undefined, 
 
 	const htmlNodeBase: IHtmlNodeBase = {
 		tagName: p5Node.tagName.toLowerCase(),
-		selfClosed: isSelfClosed(p5Node, context),
 		attributes: [],
 		location: makeHtmlNodeLocation(p5Node, context),
 		children: [],
@@ -69,17 +68,6 @@ export function parseHtmlNode(p5Node: IP5TagNode, parent: HtmlNode | undefined, 
 	htmlNode.attributes = parseHtmlNodeAttrs(p5Node, { ...context, htmlNode });
 
 	return htmlNode;
-}
-
-/**
- * Returns if this node is self-closed.
- * @param p5Node
- * @param context
- */
-function isSelfClosed(p5Node: IP5TagNode, context: ParseHtmlContext) {
-	const isEmpty = p5Node.childNodes == null || p5Node.childNodes.length === 0;
-	const isSelfClosed = getSourceLocation(p5Node)!.startTag.endOffset === getSourceLocation(p5Node)!.endOffset;
-	return isEmpty && isSelfClosed;
 }
 
 /**

--- a/packages/lit-analyzer/src/lib/analyze/types/html-node/html-node-types.ts
+++ b/packages/lit-analyzer/src/lib/analyze/types/html-node/html-node-types.ts
@@ -20,7 +20,6 @@ export interface IHtmlNodeBase {
 	attributes: HtmlNodeAttr[];
 	parent?: HtmlNode;
 	children: HtmlNode[];
-	selfClosed: boolean;
 	document: HtmlDocument;
 }
 

--- a/packages/lit-analyzer/src/lib/rules/no-unclosed-tag.ts
+++ b/packages/lit-analyzer/src/lib/rules/no-unclosed-tag.ts
@@ -2,6 +2,29 @@ import type { RuleModule } from "../analyze/types/rule/rule-module.js";
 import { isCustomElementTagName } from "../analyze/util/is-valid-name.js";
 import { rangeFromHtmlNode } from "../analyze/util/range-util.js";
 
+// List taken from https://html.spec.whatwg.org/multipage/syntax.html#void-elements
+// and parse5 list of void elements: https://github.com/inikulin/parse5/blob/86f09edd5a6840ab2269680b0eef2945e78c38fd/packages/parse5/lib/serializer/index.ts#L7-L26
+const VOID_ELEMENTS = new Set([
+	"area",
+	"base",
+	"basefont",
+	"bgsound",
+	"br",
+	"col",
+	"embed",
+	"frame",
+	"hr",
+	"img",
+	"input",
+	"keygen",
+	"link",
+	"meta",
+	"param",
+	"source",
+	"track",
+	"wbr"
+]);
+
 /**
  * This rule validates that all tags are closed properly.
  */
@@ -11,18 +34,18 @@ const rule: RuleModule = {
 		priority: "low"
 	},
 	visitHtmlNode(htmlNode, context) {
-		if (!htmlNode.selfClosed && htmlNode.location.endTag == null) {
-			// Report specifically that a custom element cannot be self closing
-			//   if the user is trying to close a custom element.
-			const isCustomElement = isCustomElementTagName(htmlNode.tagName);
-
-			context.report({
-				location: rangeFromHtmlNode(htmlNode),
-				message: `This tag isn't closed.${isCustomElement ? " Custom elements cannot be self closing." : ""}`
-			});
+		if (VOID_ELEMENTS.has(htmlNode.tagName.toLowerCase()) || htmlNode.location.endTag != null) {
+			return;
 		}
 
-		return;
+		// Report specifically that a custom element cannot be self closing
+		//   if the user is trying to close a custom element.
+		const isCustomElement = isCustomElementTagName(htmlNode.tagName);
+
+		context.report({
+			location: rangeFromHtmlNode(htmlNode),
+			message: `This tag isn't closed.${isCustomElement ? " Custom elements cannot be self closing." : ""}`
+		});
 	}
 };
 

--- a/packages/lit-analyzer/src/test/rules/no-nullable-attribute-binding.ts
+++ b/packages/lit-analyzer/src/test/rules/no-nullable-attribute-binding.ts
@@ -11,7 +11,7 @@ tsTest("Cannot assign 'undefined' in attribute binding", t => {
 tsTest("Can assign 'undefined' in property binding", t => {
 	const { diagnostics } = getDiagnostics([
 		makeElement({ slots: ["foo: number | undefined"] }),
-		'html`<my-element .foo="${{} as number | undefined}" />`'
+		'html`<my-element .foo="${{} as number | undefined}"></my-element>`'
 	]);
 	hasNoDiagnostics(t, diagnostics);
 });

--- a/packages/lit-analyzer/src/test/rules/no-unclosed-tag.ts
+++ b/packages/lit-analyzer/src/test/rules/no-unclosed-tag.ts
@@ -7,7 +7,49 @@ tsTest("Report unclosed tags", t => {
 	hasDiagnostic(t, diagnostics, "no-unclosed-tag");
 });
 
-tsTest("Don't report self closed tags", t => {
+tsTest("Don't report void elements", t => {
+	const { diagnostics } = getDiagnostics("html`<img>`", { rules: { "no-unclosed-tag": true } });
+	hasNoDiagnostics(t, diagnostics);
+});
+
+tsTest("Don't report void elements with self closing syntax", t => {
 	const { diagnostics } = getDiagnostics("html`<img />`", { rules: { "no-unclosed-tag": true } });
+	hasNoDiagnostics(t, diagnostics);
+});
+
+// The `<p>` tag will be closed automatically if immediately followed by a lot of other elements,
+// including `<div>`.
+// Ref: https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element
+tsTest("Report unclosed 'p' tag that was implicitly closed via tag omission", t => {
+	const { diagnostics } = getDiagnostics("html`<p><div></div></p>`", { rules: { "no-unclosed-tag": true } });
+	hasDiagnostic(t, diagnostics, "no-unclosed-tag");
+});
+
+tsTest("Report unclosed 'p' tag that is implicitly closed via tag omission containing text content", t => {
+	const { diagnostics } = getDiagnostics("html`<p>Unclosed Content<div></div></p>`", { rules: { "no-unclosed-tag": true } });
+	hasDiagnostic(t, diagnostics, "no-unclosed-tag");
+});
+
+// Regeression test for https://github.com/runem/lit-analyzer/issues/283
+tsTest("Report 'p' tag that is implicitly closed via tag omission containing a space", t => {
+	// Note, the browser will parse this case into: `<p> </p><div></div><p></p>` which can be
+	// unexpected, but technically means the first `<p>` tag is not explicitly closed.
+	const { diagnostics } = getDiagnostics("html`<p> <div></div></p>`", { rules: { "no-unclosed-tag": true } });
+	hasDiagnostic(t, diagnostics, "no-unclosed-tag");
+});
+
+// Self-closing tags do not exist in HTML. They are only valid in SVG and MathML.
+tsTest("Report non-void element using self closing syntax", t => {
+	const { diagnostics } = getDiagnostics("html`<p /><div></div>`", { rules: { "no-unclosed-tag": true } });
+	hasDiagnostic(t, diagnostics, "no-unclosed-tag");
+});
+
+tsTest("Report self closing 'p' tag containing text content", t => {
+	const { diagnostics } = getDiagnostics("html`<p />Unclosed Content<div></div>`", { rules: { "no-unclosed-tag": true } });
+	hasDiagnostic(t, diagnostics, "no-unclosed-tag");
+});
+
+tsTest("Don't report explicit closing 'p' tag containing text content", t => {
+	const { diagnostics } = getDiagnostics("html`<p>Unclosed Content</p><div></div>`", { rules: { "no-unclosed-tag": true } });
 	hasNoDiagnostics(t, diagnostics);
 });


### PR DESCRIPTION
> Make this lint require explicit closing tags by checking whether parse5 has got an authored location for the endTag. Because void elements do not have an endTag we also must handle them.

Not a change I made, it is taken from this PR:
https://github.com/runem/lit-analyzer/pull/340

Full details and context can be found in that PR. There are still further improvements that can be made (mentioned in that PR), but this seems like a better approach to build off of than how the rule is currently implemented.

Thank you to the original author!

