### PR TITLE
 Exclude imports with type-only bindings from list of dependencies to visit

### DIFF
--- a/.changeset/small-windows-beg.md
+++ b/.changeset/small-windows-beg.md
@@ -1,0 +1,5 @@
+---
+"lit-analyzer-fork": patch
+---
+
+Fix dependency visiting logic to exclude imports with type-only bindings

--- a/packages/lit-analyzer/src/lib/analyze/parse/parse-dependencies/visit-dependencies.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/parse-dependencies/visit-dependencies.ts
@@ -119,6 +119,18 @@ function visitDirectImports(node: Node, context: IVisitDependenciesContext): voi
 			 return;
 			 }*/
 
+			const namedBindings = context.ts.isImportDeclaration(node) && node.importClause?.namedBindings;
+
+			// Exclude files that only have type imports like `import { type MyElement } from "./file1"`
+			if (
+				namedBindings &&
+				context.ts.isNamedImports(namedBindings) &&
+				namedBindings.elements.length > 0 &&
+				namedBindings.elements.every(e => e.isTypeOnly)
+			) {
+				return;
+			}
+
 			emitDirectModuleImportWithName(node.moduleSpecifier.text, node, context);
 		}
 	}

--- a/packages/lit-analyzer/src/test/parser/dependencies/parse-dependencies.ts
+++ b/packages/lit-analyzer/src/test/parser/dependencies/parse-dependencies.ts
@@ -301,6 +301,27 @@ tsTest("Ignores type-only imports in a file", t => {
 	t.deepEqual(sortedFileNames, ["file2.ts"]);
 });
 
+tsTest("Ignores imports with type-only bindings in a file", t => {
+	const { sourceFile, context } = prepareAnalyzer([
+		{ fileName: "file1.ts", text: `` },
+		{
+			fileName: "file2.ts",
+			text: `
+				import { type MyElement } from "./file1";
+			`,
+			entry: true
+		}
+	]);
+
+	const dependencies = parseAllIndirectImports(sourceFile, context);
+
+	const sortedFileNames = Array.from(dependencies)
+		.map(file => file.fileName)
+		.sort();
+
+	t.deepEqual(sortedFileNames, ["file2.ts"]);
+});
+
 tsTest("Ignores type-only exports in a file", t => {
 	const { sourceFile, context } = prepareAnalyzer([
 		{ fileName: "file1.ts", text: `` },


### PR DESCRIPTION
Not a change I made, it is taken from this PR:
https://github.com/runem/lit-analyzer/pull/372

Not a lot of context in that PR, but I confirmed that the added test failed without this addition. It seems like a good case to handle to me.

Thank you to the original author!