### PR TITLE
Rename packages to be under @jackolope npm user scope

### DIFF
--- a/.changeset/chilled-planets-hug.md
+++ b/.changeset/chilled-planets-hug.md
@@ -1,6 +1,6 @@
 ---
-"web-component-analyzer-fork": minor
-"lit-analyzer-fork": minor
+"@jackolope/web-component-analyzer": minor
+"@jackolope/lit-analyzer": minor
 ---
 
 Support tag names which are static class properties or variables with no-missing-element-type-definition rule"

--- a/.changeset/eighty-pianos-cross.md
+++ b/.changeset/eighty-pianos-cross.md
@@ -1,5 +1,5 @@
 ---
-"lit-analyzer-fork": patch
+"@jackolope/lit-analyzer": patch
 ---
 
 Return type hint information if it is available for html-tag

--- a/.changeset/lemon-fans-scream.md
+++ b/.changeset/lemon-fans-scream.md
@@ -1,5 +1,5 @@
 ---
-"lit-analyzer-fork": patch
+"@jackolope/lit-analyzer": patch
 ---
 
 Fix ifDefined logic to exclude null from the return type, instead of just undefined

--- a/.changeset/twenty-dancers-shake.md
+++ b/.changeset/twenty-dancers-shake.md
@@ -1,7 +1,7 @@
 ---
-"web-component-analyzer-fork": patch
-"lit-analyzer-fork": patch
-"ts-lit-plugin-fork": patch
+"@jackolope/web-component-analyzer": patch
+"@jackolope/lit-analyzer": patch
+"@jackolope/ts-lit-plugin": patch
 "lit-plugin": patch
 ---
 

--- a/.changeset/wise-grapes-applaud.md
+++ b/.changeset/wise-grapes-applaud.md
@@ -1,5 +1,5 @@
 ---
-"lit-analyzer-fork": patch
+"@jackolope/lit-analyzer": patch
 ---
 
 Rework no-unclosed-tag rule to improve to cleanly check for begining and ending tags

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- ⚠️ This README has been generated from the file(s) "readme.blueprint.md" ⚠️--><h1 align="center">lit-analyzer-fork</h1>
+<!-- ⚠️ This README has been generated from the file(s) "readme.blueprint.md" ⚠️--><h1 align="center">@jackolope/lit-analyzer</h1>
 <p align="center">
   <b>Monorepo for tools that analyze lit-html templates. Updated fork of the original lit-analyzer.</b></br>
   <sub><sub>
@@ -8,9 +8,9 @@
 
 <p align="center">
 		<a href="https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin"><img alt="Downloads per Month" src="https://vsmarketplacebadges.dev/downloads-short/runem.lit-plugin.svg?label=vscode-lit-plugin" height="20"/></a>
-<a href="https://www.npmjs.com/package/lit-analyzer-fork"><img alt="Downloads per Month" src="https://img.shields.io/npm/dm/lit-analyzer-fork.svg?label=lit-analyzer-fork" height="20"/></a>
-<a href="https://www.npmjs.com/package/ts-lit-plugin-fork"><img alt="Downloads per Month" src="https://img.shields.io/npm/dm/ts-lit-plugin-fork.svg?label=ts-lit-plugin-fork" height="20"/></a>
-<a href="https://github.com/JackRobards/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/JackRobards/lit-analyzer-fork" height="20"/></a>
+<a href="https://www.npmjs.com/package/@jackolope/lit-analyzer"><img alt="Downloads per Month" src="https://img.shields.io/npm/dm/@jackolope/lit-analyzer.svg?label=@jackolope/lit-analyzer" height="20"/></a>
+<a href="https://www.npmjs.com/package/@jackolope/ts-lit-plugin"><img alt="Downloads per Month" src="https://img.shields.io/npm/dm/@jackolope/ts-lit-plugin.svg?label=@jackolope/ts-lit-plugin" height="20"/></a>
+<a href="https://github.com/JackRobards/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/JackRobards/@jackolope/lit-analyzer" height="20"/></a>
 	</p>
 
 This mono-repository consists of the following tools:

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -9,21 +9,21 @@
 			"version": "1.0.0",
 			"license": "MIT",
 			"dependencies": {
+				"@jackolope/ts-lit-plugin": "file:../packages/ts-lit-plugin",
 				"lit-element": "^2.3.1",
-				"lit-html": "^1.2.1",
-				"ts-lit-plugin-fork": "file:../packages/ts-lit-plugin"
+				"lit-html": "^1.2.1"
 			},
 			"devDependencies": {
 				"typescript": "~5.7.2"
 			}
 		},
 		"../packages/ts-lit-plugin": {
-			"name": "ts-lit-plugin-fork",
+			"name": "@jackolope/ts-lit-plugin",
 			"version": "2.0.2",
 			"license": "MIT",
 			"dependencies": {
-				"lit-analyzer-fork": "^2.0.1",
-				"web-component-analyzer-fork": "^2.0.0"
+				"@jackolope/lit-analyzer": "^2.0.1",
+				"@jackolope/web-component-analyzer": "^2.0.0"
 			},
 			"devDependencies": {
 				"@types/node": "^22.10.2",
@@ -47,6 +47,10 @@
 				"node": ">=16.7.0"
 			}
 		},
+		"node_modules/@jackolope/ts-lit-plugin": {
+			"resolved": "../packages/ts-lit-plugin",
+			"link": true
+		},
 		"node_modules/lit-element": {
 			"version": "2.5.1",
 			"license": "BSD-3-Clause",
@@ -57,10 +61,6 @@
 		"node_modules/lit-html": {
 			"version": "1.4.1",
 			"license": "BSD-3-Clause"
-		},
-		"node_modules/ts-lit-plugin-fork": {
-			"resolved": "../packages/ts-lit-plugin",
-			"link": true
 		},
 		"node_modules/typescript": {
 			"version": "5.7.2",

--- a/dev/package.json
+++ b/dev/package.json
@@ -5,7 +5,7 @@
 	"dependencies": {
 		"lit-element": "^2.3.1",
 		"lit-html": "^1.2.1",
-		"ts-lit-plugin-fork": "file:../packages/ts-lit-plugin"
+		"@jackolope/ts-lit-plugin": "file:../packages/ts-lit-plugin"
 	},
 	"devDependencies": {
 		"typescript": "~5.7.2"

--- a/dev/tsconfig.json
+++ b/dev/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"plugins": [
 			{
-				"name": "ts-lit-plugin-fork",
+				"name": "@jackolope/ts-lit-plugin",
 				"logging": "verbose",
 				"strict": true,
 				"cssTemplateTags": ["css", "scss", "sass"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "lit-analyzer-fork",
+	"name": "@jackolope/lit-analyzer",
 	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "lit-analyzer-fork",
+			"name": "@jackolope/lit-analyzer",
 			"version": "1.0.0",
 			"license": "MIT",
 			"workspaces": [
@@ -1645,6 +1645,18 @@
 			"engines": {
 				"node": ">=18.0.0"
 			}
+		},
+		"node_modules/@jackolope/lit-analyzer": {
+			"resolved": "packages/lit-analyzer",
+			"link": true
+		},
+		"node_modules/@jackolope/ts-lit-plugin": {
+			"resolved": "packages/ts-lit-plugin",
+			"link": true
+		},
+		"node_modules/@jackolope/web-component-analyzer": {
+			"resolved": "packages/web-component-analyzer",
+			"link": true
 		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.2",
@@ -7115,10 +7127,6 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
-		"node_modules/lit-analyzer-fork": {
-			"resolved": "packages/lit-analyzer",
-			"link": true
-		},
 		"node_modules/lit-plugin": {
 			"resolved": "packages/vscode-lit-plugin",
 			"link": true
@@ -9893,10 +9901,6 @@
 				"typescript": ">=4.8.4"
 			}
 		},
-		"node_modules/ts-lit-plugin-fork": {
-			"resolved": "packages/ts-lit-plugin",
-			"link": true
-		},
 		"node_modules/ts-node": {
 			"version": "10.9.2",
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -10297,10 +10301,6 @@
 			"version": "3.0.8",
 			"license": "MIT"
 		},
-		"node_modules/web-component-analyzer-fork": {
-			"resolved": "packages/web-component-analyzer",
-			"link": true
-		},
 		"node_modules/webidl-conversions": {
 			"version": "3.0.1",
 			"dev": true,
@@ -10694,10 +10694,11 @@
 			}
 		},
 		"packages/lit-analyzer": {
-			"name": "lit-analyzer-fork",
+			"name": "@jackolope/lit-analyzer",
 			"version": "2.0.3",
 			"license": "MIT",
 			"dependencies": {
+				"@jackolope/web-component-analyzer": "^2.0.0",
 				"@vscode/web-custom-data": "^0.4.2",
 				"chalk": "^5.4.0",
 				"didyoumean2": "7.0.4",
@@ -10705,11 +10706,10 @@
 				"parse5": "7.2.1",
 				"ts-simple-type": "~2.0.0-next.0",
 				"vscode-css-languageservice": "6.3.2",
-				"vscode-html-languageservice": "5.3.1",
-				"web-component-analyzer-fork": "^2.0.0"
+				"vscode-html-languageservice": "5.3.1"
 			},
 			"bin": {
-				"lit-analyzer-fork": "cli.js"
+				"lit-analyzer": "cli.js"
 			},
 			"devDependencies": {
 				"@types/node": "^22.10.2",
@@ -10724,12 +10724,12 @@
 			}
 		},
 		"packages/ts-lit-plugin": {
-			"name": "ts-lit-plugin-fork",
+			"name": "@jackolope/ts-lit-plugin",
 			"version": "2.0.2",
 			"license": "MIT",
 			"dependencies": {
-				"lit-analyzer-fork": "^2.0.1",
-				"web-component-analyzer-fork": "^2.0.0"
+				"@jackolope/lit-analyzer": "^2.0.1",
+				"@jackolope/web-component-analyzer": "^2.0.0"
 			},
 			"devDependencies": {
 				"@types/node": "^22.10.2",
@@ -10761,13 +10761,13 @@
 				"typescript": "^5.7.2"
 			},
 			"devDependencies": {
+				"@jackolope/lit-analyzer": "^2.0.3",
 				"@types/mocha": "^10.0.10",
 				"@types/node": "^22.10.2",
 				"@types/vscode": "^1.30.0",
 				"@vscode/vsce": "^3.2.1",
 				"esbuild": "^0.24.2",
 				"fast-glob": "^3.2.11",
-				"lit-analyzer-fork": "^2.0.3",
 				"mocha": "^11.0.1",
 				"wireit": "^0.1.1"
 			},
@@ -10791,7 +10791,7 @@
 			}
 		},
 		"packages/web-component-analyzer": {
-			"name": "web-component-analyzer-fork",
+			"name": "@jackolope/web-component-analyzer",
 			"version": "2.0.0",
 			"license": "MIT",
 			"dependencies": {
@@ -10802,7 +10802,7 @@
 			},
 			"bin": {
 				"wca": "cli.js",
-				"web-component-analyzer-fork": "cli.js"
+				"web-component-analyzer": "cli.js"
 			},
 			"devDependencies": {
 				"@rollup/plugin-node-resolve": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "lit-analyzer-fork",
+	"name": "@jackolope/lit-analyzer",
 	"version": "1.0.0",
 	"description": "Monorepo for tools that analyze lit-html templates. Updated fork of the original lit-analyzer.",
 	"private": true,

--- a/packages/lit-analyzer/README.md
+++ b/packages/lit-analyzer/README.md
@@ -1,4 +1,4 @@
-<!-- ⚠️ This README has been generated from the file(s) "readme.blueprint.md" ⚠️--><h1 align="center">lit-analyzer-fork</h1>
+<!-- ⚠️ This README has been generated from the file(s) "readme.blueprint.md" ⚠️--><h1 align="center">@jackolope/lit-analyzer</h1>
 <p align="center">
   <b>CLI that type checks bindings in lit-html templates</b></br>
   <sub><sub>
@@ -7,8 +7,8 @@
 <br />
 
 <p align="center">
-		<a href="https://npmcharts.com/compare/lit-analyzer-fork?minimal=true"><img alt="Downloads per month" src="https://img.shields.io/npm/dm/lit-analyzer-fork.svg" height="20"/></a>
-<a href="https://www.npmjs.com/package/lit-analyzer-fork"><img alt="NPM Version" src="https://img.shields.io/npm/v/lit-analyzer-fork.svg" height="20"/></a>
+		<a href="https://npmcharts.com/compare/@jackolope/lit-analyzer?minimal=true"><img alt="Downloads per month" src="https://img.shields.io/npm/dm/@jackolope/lit-analyzer.svg" height="20"/></a>
+<a href="https://www.npmjs.com/package/@jackolope/lit-analyzer"><img alt="NPM Version" src="https://img.shields.io/npm/v/@jackolope/lit-analyzer.svg" height="20"/></a>
 <a href="https://david-dm.org/JackRobards/lit-analyzer"><img alt="Dependencies" src="https://img.shields.io/david/JackRobards/lit-analyzer.svg" height="20"/></a>
 <a href="https://github.com/JackRobards/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/JackRobards/lit-analyzer.svg" height="20"/></a>
 	</p>
@@ -25,7 +25,7 @@ npm install lit-analyzer -g
 **Note:**
 
 - If you use Visual Studio Code you can also install the [lit-plugin](https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin) extension.
-- If you use Typescript you can also install [ts-lit-plugin-fork](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin).
+- If you use Typescript you can also install [@jackolope/ts-lit-plugin](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin).
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png)](#usage)
 
@@ -52,7 +52,7 @@ You can configure the CLI with arguments:
 lit-analyzer --strict --rules.no-unknown-tag-name off --format markdown
 ```
 
-**Note:** You can also configure the CLI using a `tsconfig.json` file (see [ts-lit-plugin-fork](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin)).
+**Note:** You can also configure the CLI using a `tsconfig.json` file (see [@jackolope/ts-lit-plugin](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin)).
 
 ### Available arguments
 

--- a/packages/lit-analyzer/package.json
+++ b/packages/lit-analyzer/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "lit-analyzer-fork",
+	"name": "@jackolope/lit-analyzer",
 	"version": "2.0.3",
 	"description": "CLI that type checks bindings in lit-html templates",
 	"author": "runem",
@@ -21,7 +21,7 @@
 		"template"
 	],
 	"bin": {
-		"lit-analyzer-fork": "cli.js"
+		"@jackolope/lit-analyzer": "cli.js"
 	},
 	"scripts": {
 		"build": "wireit",
@@ -98,7 +98,7 @@
 		"ts-simple-type": "~2.0.0-next.0",
 		"vscode-css-languageservice": "6.3.2",
 		"vscode-html-languageservice": "5.3.1",
-		"web-component-analyzer-fork": "^2.0.0"
+		"@jackolope/web-component-analyzer": "^2.0.0"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.2",

--- a/packages/lit-analyzer/readme.config.json
+++ b/packages/lit-analyzer/readme.config.json
@@ -2,6 +2,6 @@
 	"line": "rainbow",
 	"ids": {
 		"github": "JackRobards/lit-analyzer",
-		"npm": "lit-analyzer-fork"
+		"npm": "@jackolope/lit-analyzer"
 	}
 }

--- a/packages/lit-analyzer/readme/config.md
+++ b/packages/lit-analyzer/readme/config.md
@@ -7,7 +7,7 @@ You can configure the CLI with arguments:
 lit-analyzer --strict --rules.no-unknown-tag-name off --format markdown
 ```
 
-**Note:** You can also configure the CLI using a `tsconfig.json` file (see [ts-lit-plugin-fork](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin)).
+**Note:** You can also configure the CLI using a `tsconfig.json` file (see [@jackolope/ts-lit-plugin](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin)).
 
 ### Available arguments
 

--- a/packages/lit-analyzer/readme/install.md
+++ b/packages/lit-analyzer/readme/install.md
@@ -8,4 +8,4 @@ npm install lit-analyzer -g
 **Note:**
 
 - If you use Visual Studio Code you can also install the [lit-plugin](https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin) extension.
-- If you use Typescript you can also install [ts-lit-plugin-fork](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin).
+- If you use Typescript you can also install [@jackolope/ts-lit-plugin](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin).

--- a/packages/lit-analyzer/src/lib/analyze/component-analyzer/component-analyzer.ts
+++ b/packages/lit-analyzer/src/lib/analyze/component-analyzer/component-analyzer.ts
@@ -1,4 +1,4 @@
-import type { ComponentDeclaration, ComponentDefinition } from "web-component-analyzer-fork";
+import type { ComponentDeclaration, ComponentDefinition } from "@jackolope/web-component-analyzer";
 import type { LitAnalyzerContext } from "../lit-analyzer-context.js";
 import type { ReportedRuleDiagnostic } from "../rule-collection.js";
 import type { LitCodeFix } from "../types/lit-code-fix.js";

--- a/packages/lit-analyzer/src/lib/analyze/default-lit-analyzer-context.ts
+++ b/packages/lit-analyzer/src/lib/analyze/default-lit-analyzer-context.ts
@@ -1,7 +1,7 @@
 import * as tsMod from "typescript";
 import type { HostCancellationToken, Program, SourceFile, TypeChecker } from "typescript";
 import type * as tsServer from "typescript/lib/tsserverlibrary.js";
-import { analyzeHTMLElement, analyzeSourceFile } from "web-component-analyzer-fork";
+import { analyzeHTMLElement, analyzeSourceFile } from "@jackolope/web-component-analyzer";
 import { ALL_RULES } from "../rules/all-rules.js";
 import { MAX_RUNNING_TIME_PER_OPERATION } from "./constants.js";
 import { getBuiltInHtmlCollection } from "./data/get-built-in-html-collection.js";

--- a/packages/lit-analyzer/src/lib/analyze/parse/convert-component-definitions-to-html-collection.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/convert-component-definitions-to-html-collection.ts
@@ -1,7 +1,7 @@
 import type { SimpleType, SimpleTypeAny } from "ts-simple-type";
 import { isSimpleType, toSimpleType } from "ts-simple-type";
 import type { TypeChecker } from "typescript";
-import type { AnalyzerResult, ComponentDeclaration, ComponentDefinition, ComponentFeatures } from "web-component-analyzer-fork";
+import type { AnalyzerResult, ComponentDeclaration, ComponentDefinition, ComponentFeatures } from "@jackolope/web-component-analyzer";
 import { lazy } from "../util/general-util.js";
 import type { HtmlDataCollection, HtmlDataFeatures, HtmlTag } from "./parse-html-data/html-tag.js";
 

--- a/packages/lit-analyzer/src/lib/analyze/parse/parse-dependencies/parse-dependencies.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/parse-dependencies/parse-dependencies.ts
@@ -1,5 +1,5 @@
 import type { SourceFile } from "typescript";
-import type { ComponentDefinition } from "web-component-analyzer-fork";
+import type { ComponentDefinition } from "@jackolope/web-component-analyzer";
 import type { LitAnalyzerContext } from "../../lit-analyzer-context.js";
 import { visitIndirectImportsFromSourceFile } from "./visit-dependencies.js";
 

--- a/packages/lit-analyzer/src/lib/analyze/parse/parse-html-data/html-tag.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/parse-html-data/html-tag.ts
@@ -7,7 +7,7 @@ import type {
 	ComponentEvent,
 	ComponentMember,
 	ComponentSlot
-} from "web-component-analyzer-fork";
+} from "@jackolope/web-component-analyzer";
 import {
 	LIT_HTML_BOOLEAN_ATTRIBUTE_MODIFIER,
 	LIT_HTML_EVENT_LISTENER_ATTRIBUTE_MODIFIER,

--- a/packages/lit-analyzer/src/lib/analyze/rule-collection.ts
+++ b/packages/lit-analyzer/src/lib/analyze/rule-collection.ts
@@ -1,4 +1,4 @@
-import type { ComponentDeclaration, ComponentDefinition } from "web-component-analyzer-fork";
+import type { ComponentDeclaration, ComponentDefinition } from "@jackolope/web-component-analyzer";
 import type { LitAnalyzerRuleId } from "./lit-analyzer-config.js";
 import { isRuleEnabled } from "./lit-analyzer-config.js";
 import type { LitAnalyzerContext } from "./lit-analyzer-context.js";

--- a/packages/lit-analyzer/src/lib/analyze/store/analyzer-definition-store.ts
+++ b/packages/lit-analyzer/src/lib/analyze/store/analyzer-definition-store.ts
@@ -1,5 +1,5 @@
 import type { SourceFile } from "typescript";
-import type { AnalyzerResult, ComponentDeclaration, ComponentDefinition } from "web-component-analyzer-fork";
+import type { AnalyzerResult, ComponentDeclaration, ComponentDefinition } from "@jackolope/web-component-analyzer";
 
 export interface AnalyzerDefinitionStore {
 	getAnalysisResultForFile(sourceFile: SourceFile): AnalyzerResult | undefined;

--- a/packages/lit-analyzer/src/lib/analyze/store/definition-store/default-analyzer-definition-store.ts
+++ b/packages/lit-analyzer/src/lib/analyze/store/definition-store/default-analyzer-definition-store.ts
@@ -1,6 +1,6 @@
 import type { SourceFile } from "typescript";
-import type { AnalyzerResult, ComponentDeclaration, ComponentDefinition } from "web-component-analyzer-fork";
-import { visitAllHeritageClauses } from "web-component-analyzer-fork";
+import type { AnalyzerResult, ComponentDeclaration, ComponentDefinition } from "@jackolope/web-component-analyzer";
+import { visitAllHeritageClauses } from "@jackolope/web-component-analyzer";
 import { getDeclarationsInFile } from "../../util/component-util.js";
 import type { AnalyzerDefinitionStore } from "../analyzer-definition-store.js";
 

--- a/packages/lit-analyzer/src/lib/analyze/store/dependency-store/default-analyzer-dependency-store.ts
+++ b/packages/lit-analyzer/src/lib/analyze/store/dependency-store/default-analyzer-dependency-store.ts
@@ -1,5 +1,5 @@
 import type { SourceFile } from "typescript";
-import type { ComponentDefinition } from "web-component-analyzer-fork";
+import type { ComponentDefinition } from "@jackolope/web-component-analyzer";
 import type { AnalyzerDependencyStore } from "../analyzer-dependency-store.js";
 
 export class DefaultAnalyzerDependencyStore implements AnalyzerDependencyStore {

--- a/packages/lit-analyzer/src/lib/analyze/types/lit-rename-info.ts
+++ b/packages/lit-analyzer/src/lib/analyze/types/lit-rename-info.ts
@@ -1,4 +1,4 @@
-import type { ComponentDefinition } from "web-component-analyzer-fork";
+import type { ComponentDefinition } from "@jackolope/web-component-analyzer";
 import type { HtmlDocument } from "../parse/document/text-document/html-document/html-document.js";
 import type { HtmlNode } from "./html-node/html-node-types.js";
 import type { LitTargetKind } from "./lit-target-kind.js";

--- a/packages/lit-analyzer/src/lib/analyze/types/rule/rule-module.ts
+++ b/packages/lit-analyzer/src/lib/analyze/types/rule/rule-module.ts
@@ -1,4 +1,4 @@
-import type { ComponentDeclaration, ComponentDefinition, ComponentMember } from "web-component-analyzer-fork";
+import type { ComponentDeclaration, ComponentDefinition, ComponentMember } from "@jackolope/web-component-analyzer";
 import type { LitAnalyzerRuleId } from "../../lit-analyzer-config.js";
 import type { HtmlNodeAttrAssignment } from "../html-node/html-node-attr-assignment-types.js";
 import type { HtmlNodeAttr } from "../html-node/html-node-attr-types.js";

--- a/packages/lit-analyzer/src/lib/analyze/util/component-util.ts
+++ b/packages/lit-analyzer/src/lib/analyze/util/component-util.ts
@@ -1,6 +1,6 @@
 import type { SourceFile } from "typescript";
-import type { ComponentDeclaration, ComponentDefinition } from "web-component-analyzer-fork";
-import { visitAllHeritageClauses } from "web-component-analyzer-fork";
+import type { ComponentDeclaration, ComponentDefinition } from "@jackolope/web-component-analyzer";
+import { visitAllHeritageClauses } from "@jackolope/web-component-analyzer";
 
 export function getDeclarationsInFile(definition: ComponentDefinition, sourceFile: SourceFile): ComponentDeclaration[] {
 	const declarations = new Set<ComponentDeclaration>();

--- a/packages/lit-analyzer/src/lib/cli/compile.ts
+++ b/packages/lit-analyzer/src/lib/cli/compile.ts
@@ -106,7 +106,7 @@ export function resolveTsConfigCompilerOptions(): CompilerOptions | undefined {
 }
 
 /**
- * Resolves the nearest tsconfig.json and returns the configuration seed within the plugins section for "ts-lit-plugin-fork"
+ * Resolves the nearest tsconfig.json and returns the configuration seed within the plugins section for "@jackolope/ts-lit-plugin"
  */
 export function readLitAnalyzerConfigFromTsConfig(): Partial<LitAnalyzerConfig> | undefined {
 	const compilerOptions = resolveTsConfigCompilerOptions();
@@ -114,7 +114,7 @@ export function readLitAnalyzerConfigFromTsConfig(): Partial<LitAnalyzerConfig> 
 	// Finds the plugin section
 	if (compilerOptions != null && "plugins" in compilerOptions) {
 		const plugins = compilerOptions.plugins as ({ name: string } & Partial<LitAnalyzerConfig>)[];
-		const tsLitPluginOptions = plugins.find(plugin => plugin.name === "ts-lit-plugin-fork");
+		const tsLitPluginOptions = plugins.find(plugin => plugin.name === "@jackolope/ts-lit-plugin");
 		if (tsLitPluginOptions != null) {
 			return tsLitPluginOptions;
 		}

--- a/packages/lit-analyzer/src/lib/rules/no-incompatible-property-type.ts
+++ b/packages/lit-analyzer/src/lib/rules/no-incompatible-property-type.ts
@@ -1,7 +1,7 @@
 import type { SimpleType, SimpleTypeKind } from "ts-simple-type";
 import { isAssignableToSimpleTypeKind, isSimpleType, toSimpleType, typeToString } from "ts-simple-type";
 import type { Node } from "typescript";
-import type { LitElementPropertyConfig } from "web-component-analyzer-fork";
+import type { LitElementPropertyConfig } from "@jackolope/web-component-analyzer";
 import type { RuleModule } from "../analyze/types/rule/rule-module.js";
 import type { RuleModuleContext } from "../analyze/types/rule/rule-module-context.js";
 import { joinArray } from "../analyze/util/array-util.js";

--- a/packages/lit-analyzer/src/lib/rules/no-property-visibility-mismatch.ts
+++ b/packages/lit-analyzer/src/lib/rules/no-property-visibility-mismatch.ts
@@ -1,5 +1,5 @@
 import type { Identifier, ObjectLiteralExpression } from "typescript";
-import type { ComponentMember } from "web-component-analyzer-fork";
+import type { ComponentMember } from "@jackolope/web-component-analyzer";
 import type { RuleFixAction, RuleFixActionChangeRange } from "../analyze/types/rule/rule-fix-action.js";
 import type { RuleModule } from "../analyze/types/rule/rule-module.js";
 import type { RuleModuleContext } from "../analyze/types/rule/rule-module-context.js";

--- a/packages/ts-lit-plugin/README.md
+++ b/packages/ts-lit-plugin/README.md
@@ -1,4 +1,4 @@
-<!-- ⚠️ This README has been generated from the file(s) "readme.blueprint.md" ⚠️--><h1 align="center">ts-lit-plugin-fork</h1>
+<!-- ⚠️ This README has been generated from the file(s) "readme.blueprint.md" ⚠️--><h1 align="center">@jackolope/ts-lit-plugin</h1>
 <p align="center">
   <b>Typescript plugin that adds type checking and code completion to lit-html. Fork of the original ts-lit-plugin.</b></br>
   <sub><sub>
@@ -7,8 +7,8 @@
 <br />
 
 <p align="center">
-		<a href="https://npmcharts.com/compare/ts-lit-plugin-fork?minimal=true"><img alt="Downloads per month" src="https://img.shields.io/npm/dm/ts-lit-plugin-fork.svg" height="20"/></a>
-<a href="https://www.npmjs.com/package/ts-lit-plugin-fork"><img alt="NPM Version" src="https://img.shields.io/npm/v/ts-lit-plugin-fork.svg" height="20"/></a>
+		<a href="https://npmcharts.com/compare/@jackolope/ts-lit-plugin?minimal=true"><img alt="Downloads per month" src="https://img.shields.io/npm/dm/@jackolope/ts-lit-plugin.svg" height="20"/></a>
+<a href="https://www.npmjs.com/package/@jackolope/ts-lit-plugin"><img alt="NPM Version" src="https://img.shields.io/npm/v/@jackolope/ts-lit-plugin.svg" height="20"/></a>
 <a href="https://david-dm.org/JackRobards/lit-analyzer"><img alt="Dependencies" src="https://img.shields.io/david/JackRobards/lit-analyzer.svg" height="20"/></a>
 <a href="https://github.com/JackRobards/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/JackRobards/lit-analyzer.svg" height="20"/></a>
 	</p>
@@ -25,7 +25,7 @@ First, install the plugin:
 
 <!-- prettier-ignore -->
 ```bash
-npm install ts-lit-plugin-fork -D
+npm install @jackolope/ts-lit-plugin -D
 ```
 
 Then add a `plugins` section to your [`tsconfig.json`](http://www.typescriptlang.org/docs/handbook/tsconfig-json.html):
@@ -36,14 +36,14 @@ Then add a `plugins` section to your [`tsconfig.json`](http://www.typescriptlang
   "compilerOptions": {
     "plugins": [
       {
-        "name": "ts-lit-plugin-fork"
+        "name": "@jackolope/ts-lit-plugin"
       }
     ]
   }
 }
 ```
 
-Finally, restart you Typescript Language Service, and you should start getting diagnostics from `ts-lit-plugin-fork`.
+Finally, restart you Typescript Language Service, and you should start getting diagnostics from `@jackolope/ts-lit-plugin`.
 
 **Note:**
 
@@ -64,7 +64,7 @@ You can configure this plugin through your `tsconfig.json`.
   "compilerOptions": {
     "plugins": [
       {
-        "name": "ts-lit-plugin-fork",
+        "name": "@jackolope/ts-lit-plugin",
         "strict": true,
         "rules": {
           "no-unknown-tag-name": "off",

--- a/packages/ts-lit-plugin/package.json
+++ b/packages/ts-lit-plugin/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "ts-lit-plugin-fork",
+	"name": "@jackolope/ts-lit-plugin",
 	"version": "2.0.2",
 	"description": "Typescript plugin that adds type checking and code completion to lit-html. Fork of the original ts-lit-plugin.",
 	"author": "JackRobards",
@@ -55,8 +55,8 @@
 		"/html-documentation/"
 	],
 	"dependencies": {
-		"lit-analyzer-fork": "^2.0.1",
-		"web-component-analyzer-fork": "^2.0.0"
+		"@jackolope/lit-analyzer": "^2.0.1",
+		"@jackolope/web-component-analyzer": "^2.0.0"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.2",

--- a/packages/ts-lit-plugin/readme.config.json
+++ b/packages/ts-lit-plugin/readme.config.json
@@ -2,6 +2,6 @@
 	"line": "rainbow",
 	"ids": {
 		"github": "JackRobards/lit-analyzer",
-		"npm": "ts-lit-plugin-fork"
+		"npm": "@jackolope/ts-lit-plugin"
 	}
 }

--- a/packages/ts-lit-plugin/readme/config.md
+++ b/packages/ts-lit-plugin/readme/config.md
@@ -10,7 +10,7 @@ You can configure this plugin through your `tsconfig.json`.
   "compilerOptions": {
     "plugins": [
       {
-        "name": "ts-lit-plugin-fork",
+        "name": "@jackolope/ts-lit-plugin",
         "strict": true,
         "rules": {
           "no-unknown-tag-name": "off",

--- a/packages/ts-lit-plugin/readme/install.md
+++ b/packages/ts-lit-plugin/readme/install.md
@@ -4,7 +4,7 @@ First, install the plugin:
 
 <!-- prettier-ignore -->
 ```bash
-npm install ts-lit-plugin-fork -D
+npm install @jackolope/ts-lit-plugin -D
 ```
 
 Then add a `plugins` section to your [`tsconfig.json`](http://www.typescriptlang.org/docs/handbook/tsconfig-json.html):
@@ -15,14 +15,14 @@ Then add a `plugins` section to your [`tsconfig.json`](http://www.typescriptlang
   "compilerOptions": {
     "plugins": [
       {
-        "name": "ts-lit-plugin-fork"
+        "name": "@jackolope/ts-lit-plugin"
       }
     ]
   }
 }
 ```
 
-Finally, restart you Typescript Language Service, and you should start getting diagnostics from `ts-lit-plugin-fork`.
+Finally, restart you Typescript Language Service, and you should start getting diagnostics from `@jackolope/ts-lit-plugin`.
 
 **Note:**
 

--- a/packages/ts-lit-plugin/src/bazel-plugin.ts
+++ b/packages/ts-lit-plugin/src/bazel-plugin.ts
@@ -1,5 +1,5 @@
-import type { LitAnalyzerConfig, LitAnalyzerContext } from "lit-analyzer-fork";
-import { DefaultLitAnalyzerContext, LitAnalyzer, makeConfig } from "lit-analyzer-fork";
+import type { LitAnalyzerConfig, LitAnalyzerContext } from "@jackolope/lit-analyzer";
+import { DefaultLitAnalyzerContext, LitAnalyzer, makeConfig } from "@jackolope/lit-analyzer";
 import type { Diagnostic } from "typescript";
 import ts from "typescript";
 import { translateDiagnostics } from "./ts-lit-plugin/translate/translate-diagnostics.js";

--- a/packages/ts-lit-plugin/src/index.ts
+++ b/packages/ts-lit-plugin/src/index.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { LitAnalyzerConfig } from "lit-analyzer-fork";
-import { LitAnalyzerLoggerLevel, makeConfig, VERSION } from "lit-analyzer-fork";
+import type { LitAnalyzerConfig } from "@jackolope/lit-analyzer";
+import { LitAnalyzerLoggerLevel, makeConfig, VERSION } from "@jackolope/lit-analyzer";
 import type * as ts from "typescript";
 import type { CompilerOptions } from "typescript";
 import type * as tsServer from "typescript/lib/tsserverlibrary.js";
-import { VERSION as WCA_VERSION } from "web-component-analyzer-fork";
+import { VERSION as WCA_VERSION } from "@jackolope/web-component-analyzer";
 import { decorateLanguageService } from "./decorate-language-service.js";
 import { logger } from "./logger.js";
 import { LitPluginContext } from "./ts-lit-plugin/lit-plugin-context.js";
@@ -62,7 +62,7 @@ export function init({ typescript }: { typescript: typeof ts }): tsServer.server
 
 				context.updateConfig(makeConfig(info.config));
 
-				logger.verbose("Starting ts-lit-plugin-fork...");
+				logger.verbose("Starting @jackolope/ts-lit-plugin...");
 
 				if (printDebugOnce != null) printDebugOnce();
 
@@ -75,7 +75,7 @@ export function init({ typescript }: { typescript: typeof ts }): tsServer.server
 
 				return decoratedService;
 			} catch (e) {
-				logger.error("ts-lit-plugin-fork crashed while decorating the language service...", e);
+				logger.error("@jackolope/ts-lit-plugin crashed while decorating the language service...", e);
 
 				return info.languageService;
 			}
@@ -111,13 +111,13 @@ export function init({ typescript }: { typescript: typeof ts }): tsServer.server
 }
 
 /**
- * Resolves the nearest tsconfig.json and returns the configuration seed within the plugins section for "ts-lit-plugin-fork"
+ * Resolves the nearest tsconfig.json and returns the configuration seed within the plugins section for "@jackolope/ts-lit-plugin"
  */
 function readLitAnalyzerConfigFromCompilerOptions(compilerOptions: CompilerOptions): Partial<LitAnalyzerConfig> | undefined {
 	// Finds the plugin section
 	if ("plugins" in compilerOptions) {
 		const plugins = compilerOptions.plugins as ({ name: string } & Partial<LitAnalyzerConfig>)[];
-		const tsLitPluginOptions = plugins.find(plugin => plugin.name === "ts-lit-plugin-fork");
+		const tsLitPluginOptions = plugins.find(plugin => plugin.name === "@jackolope/ts-lit-plugin");
 		if (tsLitPluginOptions != null) {
 			return tsLitPluginOptions;
 		}

--- a/packages/ts-lit-plugin/src/logger.ts
+++ b/packages/ts-lit-plugin/src/logger.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { appendFileSync, writeFileSync } from "fs";
-import { DefaultLitAnalyzerLogger, LitAnalyzerLoggerLevel } from "lit-analyzer-fork";
+import { DefaultLitAnalyzerLogger, LitAnalyzerLoggerLevel } from "@jackolope/lit-analyzer";
 import { join } from "path";
 import { inspect } from "util";
 import * as tsServer from "typescript/lib/tsserverlibrary.js";
@@ -92,7 +92,7 @@ export class Logger extends DefaultLitAnalyzerLogger {
 				// ignore
 			}
 			this.tsLogger?.msg(
-				`[ts-lit-plugin-fork] ${message}`,
+				`[@jackolope/ts-lit-plugin] ${message}`,
 				level === LitAnalyzerLoggerLevel.ERROR ? tsServer.server.Msg.Err : tsServer.server.Msg.Info
 			);
 		}

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/lit-plugin-context.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/lit-plugin-context.ts
@@ -1,5 +1,5 @@
-import type { LitAnalyzerConfig } from "lit-analyzer-fork";
-import { DefaultLitAnalyzerContext } from "lit-analyzer-fork";
+import type { LitAnalyzerConfig } from "@jackolope/lit-analyzer";
+import { DefaultLitAnalyzerContext } from "@jackolope/lit-analyzer";
 import { logger } from "../logger.js";
 
 export class LitPluginContext extends DefaultLitAnalyzerContext {

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-code-fixes.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-code-fixes.ts
@@ -1,4 +1,4 @@
-import type { LitCodeFix, LitCodeFixAction } from "lit-analyzer-fork";
+import type { LitCodeFix, LitCodeFixAction } from "@jackolope/lit-analyzer";
 import type { CodeFixAction, FileTextChanges, SourceFile } from "typescript";
 import { translateRange } from "./translate-range.js";
 

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-completion-details.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-completion-details.ts
@@ -1,4 +1,4 @@
-import type { LitCompletionDetails } from "lit-analyzer-fork";
+import type { LitCompletionDetails } from "@jackolope/lit-analyzer";
 import type { CompletionEntryDetails } from "typescript";
 import type { LitPluginContext } from "../lit-plugin-context.js";
 

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-completions.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-completions.ts
@@ -1,4 +1,4 @@
-import type { LitCompletion } from "lit-analyzer-fork";
+import type { LitCompletion } from "@jackolope/lit-analyzer";
 import type { CompletionEntry, CompletionInfo } from "typescript";
 import { translateRange } from "./translate-range.js";
 import { translateTargetKind } from "./translate-target-kind.js";

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-definition.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-definition.ts
@@ -1,4 +1,4 @@
-import type { LitDefinition, LitDefinitionTarget } from "lit-analyzer-fork";
+import type { LitDefinition, LitDefinitionTarget } from "@jackolope/lit-analyzer";
 import type { DefinitionInfo, DefinitionInfoAndBoundSpan } from "typescript";
 import { tsModule } from "../../ts-module.js";
 import { translateRange } from "./translate-range.js";

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-diagnostics.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-diagnostics.ts
@@ -1,4 +1,4 @@
-import type { LitAnalyzerContext, LitDiagnostic } from "lit-analyzer-fork";
+import type { LitAnalyzerContext, LitDiagnostic } from "@jackolope/lit-analyzer";
 import type { DiagnosticMessageChain, DiagnosticWithLocation, SourceFile } from "typescript";
 import { translateRange } from "./translate-range.js";
 

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-format-edits.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-format-edits.ts
@@ -1,4 +1,4 @@
-import type { LitFormatEdit } from "lit-analyzer-fork";
+import type { LitFormatEdit } from "@jackolope/lit-analyzer";
 import type * as ts from "typescript";
 import { translateRange } from "./translate-range.js";
 

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-outlining-spans.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-outlining-spans.ts
@@ -1,4 +1,4 @@
-import type { LitOutliningSpan } from "lit-analyzer-fork";
+import type { LitOutliningSpan } from "@jackolope/lit-analyzer";
 import { translateRange } from "./translate-range.js";
 import type * as ts from "typescript";
 

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-quick-info.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-quick-info.ts
@@ -1,4 +1,4 @@
-import type { LitQuickInfo } from "lit-analyzer-fork";
+import type { LitQuickInfo } from "@jackolope/lit-analyzer";
 import type { QuickInfo } from "typescript";
 import { tsModule } from "../../ts-module.js";
 import { translateRange } from "./translate-range.js";

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-range.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-range.ts
@@ -1,4 +1,4 @@
-import type { Range } from "lit-analyzer-fork";
+import type { Range } from "@jackolope/lit-analyzer";
 import type { TextSpan } from "typescript";
 
 export function translateRange(range: Range): TextSpan {

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-rename-info.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-rename-info.ts
@@ -1,4 +1,4 @@
-import type { LitRenameInfo } from "lit-analyzer-fork";
+import type { LitRenameInfo } from "@jackolope/lit-analyzer";
 import type { RenameInfo } from "typescript";
 import { translateTargetKind } from "./translate-target-kind.js";
 import { translateRange } from "./translate-range.js";

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-rename-locations.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-rename-locations.ts
@@ -1,4 +1,4 @@
-import type { LitRenameLocation } from "lit-analyzer-fork";
+import type { LitRenameLocation } from "@jackolope/lit-analyzer";
 import { translateRange } from "./translate-range.js";
 import type { RenameLocation } from "typescript";
 

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-target-kind.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/translate/translate-target-kind.ts
@@ -1,4 +1,4 @@
-import type { LitTargetKind } from "lit-analyzer-fork";
+import type { LitTargetKind } from "@jackolope/lit-analyzer";
 import type { ScriptElementKind } from "typescript";
 import { tsModule } from "../../ts-module.js";
 

--- a/packages/ts-lit-plugin/src/ts-lit-plugin/ts-lit-plugin.ts
+++ b/packages/ts-lit-plugin/src/ts-lit-plugin/ts-lit-plugin.ts
@@ -1,4 +1,4 @@
-import { LitAnalyzer } from "lit-analyzer-fork";
+import { LitAnalyzer } from "@jackolope/lit-analyzer";
 import type {
 	CodeFixAction,
 	CompletionEntryDetails,

--- a/packages/vscode-lit-plugin/README.md
+++ b/packages/vscode-lit-plugin/README.md
@@ -650,7 +650,7 @@ css`
 
 You can configure this plugin by going to `VS Code Settings` > `Extension` > `lit-plugin`.
 
-**Note:** You can also configure the plugin using a `tsconfig.json` file (see [ts-lit-plugin-fork](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin)).
+**Note:** You can also configure the plugin using a `tsconfig.json` file (see [@jackolope/ts-lit-plugin](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin)).
 
 ### Available options
 
@@ -785,7 +785,7 @@ Below is a comparison table of the two plugins:
 
 All features are provided by these three libraries:
 
-- **[ts-lit-plugin-fork](https://github.com/JackRobards/lit-analyzer)**: The typescript plugin that powers the logic through the typescript language service (code completion, type checking, eg.). Therefore issues regarding anything but syntax highlighting should be opened in `ts-lit-plugin` and not `vscode-lit-plugin`.
+- **[@jackolope/ts-lit-plugin](https://github.com/JackRobards/lit-analyzer)**: The typescript plugin that powers the logic through the typescript language service (code completion, type checking, eg.). Therefore issues regarding anything but syntax highlighting should be opened in `ts-lit-plugin` and not `vscode-lit-plugin`.
 - **[vscode-lit-html](https://github.com/mjbvz/vscode-lit-html)**: Provides highlighting for the html template tag.
 - **[vscode-styled-components](https://github.com/styled-components/vscode-styled-components)**: Provides highlighting for the css template tag.
 

--- a/packages/vscode-lit-plugin/copy-to-built.js
+++ b/packages/vscode-lit-plugin/copy-to-built.js
@@ -20,19 +20,19 @@ async function main() {
 
 	// For the TS compiler plugin, it must be in node modules because that's
 	// hard coded by the TS compiler's custom module resolution logic.
-	await mkdirp("./built/node_modules/ts-lit-plugin-fork");
+	await mkdirp("./built/node_modules/@jackolope/ts-lit-plugin");
 	const tsPluginPackageJson = require("../ts-lit-plugin/package.json");
 	// We're only using the bundled version, so the plugin doesn't need any
 	// dependencies.
 	tsPluginPackageJson.dependencies = {};
-	await writeFile("./built/node_modules/ts-lit-plugin-fork/package.json", JSON.stringify(tsPluginPackageJson, null, 2));
-	await copy("../ts-lit-plugin/index.js", "./built/node_modules/ts-lit-plugin-fork/index.js");
+	await writeFile("./built/node_modules/@jackolope/ts-lit-plugin/package.json", JSON.stringify(tsPluginPackageJson, null, 2));
+	await copy("../ts-lit-plugin/index.js", "./built/node_modules/@jackolope/ts-lit-plugin/index.js");
 
 	const pluginPackageJson = require("./package.json");
 	// vsce is _very_ picky about the directories in node_modules matching the
-	// extension's package.json, so we need an entry for ts-lit-plugin-fork or it
+	// extension's package.json, so we need an entry for @jackolope/ts-lit-plugin or it
 	// will think that it's extraneous.
-	pluginPackageJson.dependencies["ts-lit-plugin-fork"] = "*";
+	pluginPackageJson.dependencies["@jackolope/ts-lit-plugin"] = "*";
 	await writeFile("./built/package.json", JSON.stringify(pluginPackageJson, null, 2));
 
 	// Copy static files used by the extension.

--- a/packages/vscode-lit-plugin/esbuild.script.mjs
+++ b/packages/vscode-lit-plugin/esbuild.script.mjs
@@ -16,7 +16,7 @@ await esbuild.build({
 await esbuild.build({
 	entryPoints: ["../ts-lit-plugin/src/index.ts"],
 	bundle: true,
-	outfile: "built/node_modules/ts-lit-plugin-fork/lib/index.js",
+	outfile: "built/node_modules/@jackolope/ts-lit-plugin/lib/index.js",
 	platform: "node",
 	external: ["typescript"],
 	minify: true,

--- a/packages/vscode-lit-plugin/package.json
+++ b/packages/vscode-lit-plugin/package.json
@@ -132,7 +132,7 @@
 			],
 			"output": [
 				"built/bundle.js",
-				"built/node_modules/ts-lit-plugin-fork/index.js"
+				"built/node_modules/@jackolope/ts-lit-plugin/index.js"
 			]
 		},
 		"make-built-dir": {
@@ -153,8 +153,8 @@
 			"output": [
 				"built/docs",
 				"built/node_modules/typescript",
-				"built/node_modules/ts-lit-plugin-fork/package.json",
-				"built/node_modules/ts-lit-plugin-fork/index.js",
+				"built/node_modules/@jackolope/ts-lit-plugin/package.json",
+				"built/node_modules/@jackolope/ts-lit-plugin/index.js",
 				"built/schemas",
 				"built/syntaxes",
 				"built/LICENSE.md",
@@ -174,7 +174,7 @@
 		"@vscode/vsce": "^3.2.1",
 		"esbuild": "^0.24.2",
 		"fast-glob": "^3.2.11",
-		"lit-analyzer-fork": "^2.0.3",
+		"@jackolope/lit-analyzer": "^2.0.3",
 		"mocha": "^11.0.1",
 		"wireit": "^0.1.1"
 	},
@@ -752,7 +752,7 @@
 		],
 		"typescriptServerPlugins": [
 			{
-				"name": "ts-lit-plugin-fork",
+				"name": "@jackolope/ts-lit-plugin",
 				"enableForWorkspaceTypeScriptVersions": true
 			}
 		],

--- a/packages/vscode-lit-plugin/readme/config.md
+++ b/packages/vscode-lit-plugin/readme/config.md
@@ -2,7 +2,7 @@
 
 You can configure this plugin by going to `VS Code Settings` > `Extension` > `lit-plugin`.
 
-**Note:** You can also configure the plugin using a `tsconfig.json` file (see [ts-lit-plugin-fork](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin)).
+**Note:** You can also configure the plugin using a `tsconfig.json` file (see [@jackolope/ts-lit-plugin](https://github.com/JackRobards/lit-analyzer/blob/master/packages/ts-lit-plugin)).
 
 ### Available options
 

--- a/packages/vscode-lit-plugin/readme/how.md
+++ b/packages/vscode-lit-plugin/readme/how.md
@@ -2,7 +2,7 @@
 
 All features are provided by these three libraries:
 
-- **[ts-lit-plugin-fork](https://github.com/JackRobards/lit-analyzer)**: The typescript plugin that powers the logic through the typescript language service (code completion, type checking, eg.). Therefore issues regarding anything but syntax highlighting should be opened in `ts-lit-plugin` and not `vscode-lit-plugin`.
+- **[@jackolope/ts-lit-plugin](https://github.com/JackRobards/lit-analyzer)**: The typescript plugin that powers the logic through the typescript language service (code completion, type checking, eg.). Therefore issues regarding anything but syntax highlighting should be opened in `ts-lit-plugin` and not `vscode-lit-plugin`.
 - **[vscode-lit-html](https://github.com/mjbvz/vscode-lit-html)**: Provides highlighting for the html template tag.
 - **[vscode-styled-components](https://github.com/styled-components/vscode-styled-components)**: Provides highlighting for the css template tag.
 

--- a/packages/vscode-lit-plugin/schemas/tsconfig.schema.json
+++ b/packages/vscode-lit-plugin/schemas/tsconfig.schema.json
@@ -12,7 +12,7 @@
 						"if": {
 							"properties": {
 								"name": {
-									"enum": ["ts-lit-plugin-fork"]
+									"enum": ["@jackolope/ts-lit-plugin"]
 								}
 							},
 							"required": ["name"]

--- a/packages/vscode-lit-plugin/src/extension.ts
+++ b/packages/vscode-lit-plugin/src/extension.ts
@@ -1,10 +1,10 @@
-import type { LitAnalyzerConfig } from "lit-analyzer-fork";
-import { ALL_RULE_IDS } from "lit-analyzer-fork";
+import type { LitAnalyzerConfig } from "@jackolope/lit-analyzer";
+import { ALL_RULE_IDS } from "@jackolope/lit-analyzer";
 import { join } from "path";
 import { ColorProvider } from "./color-provider.js";
 import * as vscode from "vscode";
 
-const tsLitPluginId = "ts-lit-plugin-fork";
+const tsLitPluginId = "@jackolope/ts-lit-plugin";
 const typeScriptExtensionId = "vscode.typescript-language-features";
 const configurationSection = "lit-plugin";
 const configurationExperimentalHtmlSection = "html.experimental";
@@ -212,7 +212,7 @@ function handleAnalyzeCommand() {
 			defaultAnalyzeGlob = glob;
 
 			const cliCommand = `npx lit-analyzer "${glob}"`;
-			const terminal = vscode.window.createTerminal("lit-analyzer-fork");
+			const terminal = vscode.window.createTerminal("@jackolope/lit-analyzer");
 			terminal.sendText(cliCommand, true);
 			terminal.show(true);
 		});

--- a/packages/web-component-analyzer/README.md
+++ b/packages/web-component-analyzer/README.md
@@ -1,8 +1,8 @@
 <h1 align="center">web-component-analyzer</h1>
 
 <p align="center">
-	<a href="https://npmcharts.com/compare/web-component-analyzer-fork?minimal=true"><img alt="Downloads per month" src="https://img.shields.io/npm/dm/web-component-analyzer-fork.svg" height="20"/></a>
-	<a href="https://www.npmjs.com/package/web-component-analyzer-fork"><img alt="NPM Version" src="https://img.shields.io/npm/v/web-component-analyzer-fork.svg" height="20"/></a>
+	<a href="https://npmcharts.com/compare/@jackolope/web-component-analyzer?minimal=true"><img alt="Downloads per month" src="https://img.shields.io/npm/dm/@jackolope/web-component-analyzer.svg" height="20"/></a>
+	<a href="https://www.npmjs.com/package/@jackolope/web-component-analyzer"><img alt="NPM Version" src="https://img.shields.io/npm/v/@jackolope/web-component-analyzer.svg" height="20"/></a>
 	<a href="https://david-dm.org/JackRobards/lit-analyzer"><img alt="Dependencies" src="https://img.shields.io/david/JackRobards/lit-analyzer.svg" height="20"/></a>
 	<a href="https://github.com/JackRobards/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/JackRobards/lit-analyzer.svg" height="20"/></a>
 </p>
@@ -11,7 +11,7 @@
   <img src="https://user-images.githubusercontent.com/5372940/68087781-1044ce80-fe59-11e9-969c-4234f9287f1b.gif" alt="Web component analyzer GIF"/>
 </p>
 
-`web-component-analyzer-fork` is a CLI that makes it possible to easily analyze web components. It analyzes your code and jsdoc in order to extract `properties`, `attributes`, `methods`, `events`, `slots`, `css shadow parts` and `css custom properties`. Works with both javascript and typescript.
+`@jackolope/web-component-analyzer` is a CLI that makes it possible to easily analyze web components. It analyzes your code and jsdoc in order to extract `properties`, `attributes`, `methods`, `events`, `slots`, `css shadow parts` and `css custom properties`. Works with both javascript and typescript.
 
 Try the online playground [here](https://runem.github.io/web-component-analyzer/)
 
@@ -29,14 +29,14 @@ In addition to [vanilla web components](https://developer.mozilla.org/en-US/docs
 
 <!-- prettier-ignore -->
 ```bash
-$ npm install -g web-component-analyzer-fork
+$ npm install -g @jackolope/web-component-analyzer
 ```
 
 **or**
 
 <!-- prettier-ignore -->
 ```bash
-$ npx web-component-analyzer-fork src
+$ npx @jackolope/web-component-analyzer src
 ```
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#usage)
@@ -203,7 +203,7 @@ You can also directly use the underlying functionality of this tool if you don't
 
 <!-- prettier-ignore -->
 ```typescript
-import { analyzeSourceFile } from "web-component-analyzer-fork";
+import { analyzeSourceFile } from "@jackolope/web-component-analyzer";
 
 const result = analyzeSourceFile(sourceFile, { checker });
 ```
@@ -212,7 +212,7 @@ const result = analyzeSourceFile(sourceFile, { checker });
 
 <!-- prettier-ignore -->
 ```javascript
-import { analyzeText } from "web-component-analyzer-fork";
+import { analyzeText } from "@jackolope/web-component-analyzer";
 
 const code = `class MyElement extends HTMLElement {
 
@@ -236,7 +236,7 @@ const { results, program } = analyzeText([
 
 <!-- prettier-ignore -->
 ```javascript
-import { transformAnalyzerResult } from "web-component-analyzer-fork";
+import { transformAnalyzerResult } from "@jackolope/web-component-analyzer";
 
 const result = // the result of analyzing the component using one of the above functions
 

--- a/packages/web-component-analyzer/package.json
+++ b/packages/web-component-analyzer/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "web-component-analyzer-fork",
+	"name": "@jackolope/web-component-analyzer",
 	"version": "2.0.0",
 	"description": "CLI that analyzes web components",
 	"main": "lib/cjs/api.js",
@@ -132,6 +132,6 @@
 	},
 	"bin": {
 		"wca": "cli.js",
-		"web-component-analyzer-fork": "cli.js"
+		"@jackolope/web-component-analyzer": "cli.js"
 	}
 }

--- a/readme.config.json
+++ b/readme.config.json
@@ -8,17 +8,17 @@
 		},
 		{
 			"alt": "Downloads per Month",
-			"img": "https://img.shields.io/npm/dm/lit-analyzer-fork.svg?label=lit-analyzer-fork",
-			"url": "https://www.npmjs.com/package/lit-analyzer-fork"
+			"img": "https://img.shields.io/npm/dm/@jackolope/lit-analyzer.svg?label=@jackolope/lit-analyzer",
+			"url": "https://www.npmjs.com/package/@jackolope/lit-analyzer"
 		},
 		{
 			"alt": "Downloads per Month",
-			"img": "https://img.shields.io/npm/dm/ts-lit-plugin-fork.svg?label=ts-lit-plugin-fork",
-			"url": "https://www.npmjs.com/package/ts-lit-plugin-fork"
+			"img": "https://img.shields.io/npm/dm/@jackolope/ts-lit-plugin.svg?label=@jackolope/ts-lit-plugin",
+			"url": "https://www.npmjs.com/package/@jackolope/ts-lit-plugin"
 		},
 		{
 			"alt": "Contributors",
-			"img": "https://img.shields.io/github/contributors/JackRobards/lit-analyzer-fork",
+			"img": "https://img.shields.io/github/contributors/JackRobards/@jackolope/lit-analyzer",
 			"url": "https://github.com/JackRobards/lit-analyzer/graphs/contributors"
 		}
 	]


### PR DESCRIPTION
Prior to actually publishing these packages, grouping them under a scope seems nicer than just appending `-fork` to their names.