### PR TITLE
Update publisher to new name for VSCode extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"scripts": {
 		"prettier:write": "prettier --write \"packages/*/src/**/*.ts\"",
 		"readme": "wireit",
-		"dev": "cd dev && TSS_DEBUG=5999 code . --disable-extension runem.lit-plugin",
+		"dev": "cd dev && TSS_DEBUG=5999 code . --disable-extension jackolope.lit-plugin",
 		"dev:logs": "touch dev/lit-plugin.log && tail -f dev/lit-plugin.log",
 		"lint": "wireit",
 		"eslint": "wireit",

--- a/packages/vscode-lit-plugin/package.json
+++ b/packages/vscode-lit-plugin/package.json
@@ -4,7 +4,7 @@
 	"displayName": "lit-plugin",
 	"description": "Syntax highlighting, type checking and code completion for lit-html",
 	"version": "1.4.3",
-	"publisher": "runem",
+	"publisher": "jackolope",
 	"icon": "docs/assets/lit-plugin@256w.png",
 	"license": "MIT",
 	"engines": {
@@ -15,8 +15,7 @@
 	],
 	"homepage": "https://github.com/JackRobards/lit-analyzer",
 	"bugs": {
-		"url": "https://github.com/JackRobards/lit-analyzer/issues",
-		"email": "runemehlsen@gmail.com"
+		"url": "https://github.com/JackRobards/lit-analyzer/issues"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/vscode-lit-plugin/readme.config.json
+++ b/packages/vscode-lit-plugin/readme.config.json
@@ -7,13 +7,13 @@
 	"badges": [
 		{
 			"alt": "Published at vscode marketplace",
-			"url": "https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin",
-			"img": "https://vsmarketplacebadges.dev/version/runem.lit-plugin.svg"
+			"url": "https://marketplace.visualstudio.com/items?itemName=jackolope.lit-plugin",
+			"img": "https://vsmarketplacebadges.dev/version/jackolope.lit-plugin.svg"
 		},
 		{
 			"alt": "Downloads per Month",
-			"img": "https://vsmarketplacebadges.dev/downloads-short/runem.lit-plugin.svg?label=vscode-lit-plugin",
-			"url": "https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin"
+			"img": "https://vsmarketplacebadges.dev/downloads-short/jackolope.lit-plugin.svg?label=vscode-lit-plugin",
+			"url": "https://marketplace.visualstudio.com/items?itemName=jackolope.lit-plugin"
 		}
 	]
 }

--- a/packages/vscode-lit-plugin/src/test/simple-test.ts
+++ b/packages/vscode-lit-plugin/src/test/simple-test.ts
@@ -28,7 +28,7 @@ suite("Extension Test Suite", () => {
 
 	test("The extension is installed", () => {
 		const extensionIds = vscode.extensions.all.map(extension => extension.id);
-		const ourId = "runem.lit-plugin";
+		const ourId = "jackolope.lit-plugin";
 		assert.ok(extensionIds.includes(ourId), `Expected ${JSON.stringify(extensionIds)} to include '${ourId}'`);
 	});
 

--- a/readme.config.json
+++ b/readme.config.json
@@ -3,8 +3,8 @@
 	"badges": [
 		{
 			"alt": "Downloads per Month",
-			"img": "https://vsmarketplacebadges.dev/downloads-short/runem.lit-plugin.svg?label=vscode-lit-plugin",
-			"url": "https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin"
+			"img": "https://vsmarketplacebadges.dev/downloads-short/jackolope.lit-plugin.svg?label=vscode-lit-plugin",
+			"url": "https://marketplace.visualstudio.com/items?itemName=jackolope.lit-plugin"
 		},
 		{
 			"alt": "Downloads per Month",


### PR DESCRIPTION
So that the fork can be published to VSCode, created a new VSCode Publisher and Azure Devops account.

For now the publishing is not automated, but this workflow looks like an option to potentially enable that in the future:
https://github.com/marketplace/actions/publish-vs-code-extension