### PR TITLE
chore: Add changeset files for major release

### DIFF
--- a/.changeset/breezy-toes-attack.md
+++ b/.changeset/breezy-toes-attack.md
@@ -9,13 +9,14 @@ Bulk Minor/Patch Changes
 
 - Upgrade the html and css language service packages, so that the plugin can detect the latest features.
 - Generally, all packages have been upgraded in (or uninstalled from) the repo. This includes a number of security fixes, and many of these PRs were handled by Dependabot.
-- fix: Exclude symbol when checking binding types: https://github.com/JackRobards/lit-analyzer/pull/107
+- fix: Exclude symbol when checking binding types: https://github.com/JackRobards/lit-analyzer/pull/107.
 
 Dev related (doesn't effect consumers):
 
-- Migrade to npm workspaces: https://github.com/JackRobards/lit-analyzer/pull/28
+- Migrate to npm workspaces: https://github.com/JackRobards/lit-analyzer/pull/28.
 - The web-component-analyzer repo has also been forked, and is no included in this monorepo: https://github.com/JackRobards/lit-analyzer/pull/59.
 - Upgrade and fix the broken .github scripts to build on PRs: https://github.com/JackRobards/lit-analyzer/pull/4 and https://github.com/JackRobards/lit-analyzer/pull/5.
 - Migrate repository to new ESLint flat config: https://github.com/JackRobards/lit-analyzer/pull/99.
-- Upgrade ava testing package to the latest version (required some manual changes): https://github.com/JackRobards/lit-analyzer/pull/8
+- Upgrade ava testing package to the latest version (required some manual changes): https://github.com/JackRobards/lit-analyzer/pull/8.
+- Dependabot is now active in this repo, to help keep it up to date with new releases.
 - In future release notes, not all of these dev-related changes will be included in the changelog. For this initial release, they are included to help track what all has been updated with this fork.

--- a/.changeset/breezy-toes-attack.md
+++ b/.changeset/breezy-toes-attack.md
@@ -1,0 +1,21 @@
+---
+"@jackolope/lit-analyzer": minor
+"@jackolope/ts-lit-plugin": minor
+"lit-plugin": minor
+"@jackolope/web-component-analyzer": minor
+---
+
+Bulk Minor/Patch Changes
+
+- Upgrade the html and css language service packages, so that the plugin can detect the latest features.
+- Generally, all packages have been upgraded in (or uninstalled from) the repo. This includes a number of security fixes, and many of these PRs were handled by Dependabot.
+- fix: Exclude symbol when checking binding types: https://github.com/JackRobards/lit-analyzer/pull/107
+
+Dev related (doesn't effect consumers):
+
+- Migrade to npm workspaces: https://github.com/JackRobards/lit-analyzer/pull/28
+- The web-component-analyzer repo has also been forked, and is no included in this monorepo: https://github.com/JackRobards/lit-analyzer/pull/59.
+- Upgrade and fix the broken .github scripts to build on PRs: https://github.com/JackRobards/lit-analyzer/pull/4 and https://github.com/JackRobards/lit-analyzer/pull/5.
+- Migrate repository to new ESLint flat config: https://github.com/JackRobards/lit-analyzer/pull/99.
+- Upgrade ava testing package to the latest version (required some manual changes): https://github.com/JackRobards/lit-analyzer/pull/8
+- In future release notes, not all of these dev-related changes will be included in the changelog. For this initial release, they are included to help track what all has been updated with this fork.

--- a/.changeset/long-ducks-shave.md
+++ b/.changeset/long-ducks-shave.md
@@ -1,0 +1,14 @@
+---
+"@jackolope/lit-analyzer": major
+"@jackolope/ts-lit-plugin": major
+"lit-plugin": major
+"@jackolope/web-component-analyzer": major
+---
+
+Major (Breaking) changes:
+
+- Upgrade Supported Node versions to 18, 20, and 22: https://github.com/JackRobards/lit-analyzer/pull/27
+- Upgrade to the latest version of vsce, for building and publishing the VSCode Extension: https://github.com/JackRobards/lit-analyzer/pull/45 and https://github.com/JackRobards/lit-analyzer/pull/47.
+- Upgrade TypeScript Versions tested against to 5.4, 5.5, 5.6, 5.7 (previously it was 4.8 - 5.2): https://github.com/JackRobards/lit-analyzer/pull/75
+- Upgrade tsconfig to target es2023 and the NodeNext module. Previously it was targeting es5 and commonjs: https://github.com/JackRobards/lit-analyzer/pull/95
+- NPM Packages renamed to have be prefixed with @jackolope user scope: https://github.com/JackRobards/lit-analyzer/pull/114 and https://github.com/JackRobards/lit-analyzer/pull/94

--- a/.changeset/long-ducks-shave.md
+++ b/.changeset/long-ducks-shave.md
@@ -7,8 +7,8 @@
 
 Major (Breaking) changes:
 
-- Upgrade Supported Node versions to 18, 20, and 22: https://github.com/JackRobards/lit-analyzer/pull/27
+- Upgrade Supported Node versions to 18, 20, and 22: https://github.com/JackRobards/lit-analyzer/pull/27.
 - Upgrade to the latest version of vsce, for building and publishing the VSCode Extension: https://github.com/JackRobards/lit-analyzer/pull/45 and https://github.com/JackRobards/lit-analyzer/pull/47.
-- Upgrade TypeScript Versions tested against to 5.4, 5.5, 5.6, 5.7 (previously it was 4.8 - 5.2): https://github.com/JackRobards/lit-analyzer/pull/75
-- Upgrade tsconfig to target es2023 and the NodeNext module. Previously it was targeting es5 and commonjs: https://github.com/JackRobards/lit-analyzer/pull/95
-- NPM Packages renamed to have be prefixed with @jackolope user scope: https://github.com/JackRobards/lit-analyzer/pull/114 and https://github.com/JackRobards/lit-analyzer/pull/94
+- Upgrade TypeScript Versions tested against to 5.4, 5.5, 5.6, 5.7 (previously it was 4.8 - 5.2): https://github.com/JackRobards/lit-analyzer/pull/75.
+- Upgrade tsconfig to target es2023 and the NodeNext module. Previously it was targeting es5 and commonjs: https://github.com/JackRobards/lit-analyzer/pull/95.
+- NPM Packages renamed to have be prefixed with @jackolope user scope: https://github.com/JackRobards/lit-analyzer/pull/114 and https://github.com/JackRobards/lit-analyzer/pull/94.


### PR DESCRIPTION
Bulk description of what was changed before the initial PR that added the .changesets package to this repo.

See the individual linked PRs next to each change for details on that specific change. Going forward .changesets will be included as part of any PR that changes a user-facing feature.

I have decided to bump the major version on all packages, to help make it clear this is intended to be a continuation of existing packages and that there are breaking changes from the previous versions.