### PR TITLE
chore: Fix release script and update package-lock to new versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10687,10 +10687,10 @@
 		},
 		"packages/lit-analyzer": {
 			"name": "@jackolope/lit-analyzer",
-			"version": "2.0.3",
+			"version": "3.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"@jackolope/web-component-analyzer": "^2.0.0",
+				"@jackolope/web-component-analyzer": "^3.0.0",
 				"@vscode/web-custom-data": "^0.4.2",
 				"chalk": "^5.4.0",
 				"didyoumean2": "7.0.4",
@@ -10720,11 +10720,11 @@
 		},
 		"packages/ts-lit-plugin": {
 			"name": "@jackolope/ts-lit-plugin",
-			"version": "2.0.2",
+			"version": "3.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"@jackolope/lit-analyzer": "^2.0.1",
-				"@jackolope/web-component-analyzer": "^2.0.0"
+				"@jackolope/lit-analyzer": "^3.0.0",
+				"@jackolope/web-component-analyzer": "^3.0.0"
 			},
 			"devDependencies": {
 				"@types/node": "^22.10.7",
@@ -10753,13 +10753,13 @@
 		},
 		"packages/vscode-lit-plugin": {
 			"name": "lit-plugin",
-			"version": "1.4.3",
+			"version": "2.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"typescript": "^5.7.2"
 			},
 			"devDependencies": {
-				"@jackolope/lit-analyzer": "^2.0.3",
+				"@jackolope/lit-analyzer": "^3.0.0",
 				"@types/mocha": "^10.0.10",
 				"@types/node": "^22.10.7",
 				"@types/vscode": "^1.30.0",
@@ -10791,7 +10791,7 @@
 		},
 		"packages/web-component-analyzer": {
 			"name": "@jackolope/web-component-analyzer",
-			"version": "2.0.0",
+			"version": "3.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"fast-glob": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"test:packaged": "wireit",
 		"prettier:check": "wireit",
 		"package": "wireit",
-		"release": "npm run build && npm run changeset publish"
+		"release": "npm run build && npx changeset publish"
 	},
 	"wireit": {
 		"build": {

--- a/packages/lit-analyzer/src/lib/analyze/constants.ts
+++ b/packages/lit-analyzer/src/lib/analyze/constants.ts
@@ -16,6 +16,6 @@ export const DIAGNOSTIC_SOURCE = "lit-plugin";
 
 export const TS_IGNORE_FLAG = "@ts-ignore";
 
-export const VERSION = "2.0.3";
+export const VERSION = "3.0.0";
 
 export const MAX_RUNNING_TIME_PER_OPERATION = 150; // Default to small timeouts. Opt in to larger timeouts where necessary.


### PR DESCRIPTION
I had put the wrong command in the npm script, and the Changesets release PR did not update the root package-lock.json file for the internal packages.