### PR TITLE
Fix typescript lit analyzer cli support for older versions of TypeScript (<5.5)

### DIFF
--- a/.changeset/empty-geese-study.md
+++ b/.changeset/empty-geese-study.md
@@ -1,0 +1,5 @@
+---
+"@jackolope/lit-analyzer": patch
+---
+
+fix: lit-analyzer CLI stopped working when the workspace version of TypeScript was < 5.5

--- a/packages/lit-analyzer/src/lib/cli/compile.mts
+++ b/packages/lit-analyzer/src/lib/cli/compile.mts
@@ -1,16 +1,16 @@
 import { existsSync, readFileSync } from "fs";
 import type { CompilerOptions, Program, SourceFile } from "typescript";
-import {
-	parseJsonConfigFileContent,
-	sys,
-	createProgram,
-	findConfigFile,
-	ModuleKind,
-	ModuleResolutionKind,
-	readConfigFile,
-	ScriptTarget
-} from "typescript";
 import type { LitAnalyzerConfig } from "../analyze/lit-analyzer-config.js";
+
+// Since we use the project version of TypeScript `typescript`, we must use a default import here for compatibility. Not all of these modules are exported by name in older versions.
+// If we only supported TypeScript >= 5.5, then we could change this back to a normal, non-default, import.
+// The update that fixed this: https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#easier-api-consumption-from-ecmascript-modules
+//
+// Without this, the error message we can run into is:
+// SyntaxError: Named export 'ModuleKind' not found. The requested module 'typescript' is a CommonJS module, which may not support all module.exports as named exports.
+// CommonJS modules can always be imported via the default export, for example using:
+import pkg from "typescript";
+const { parseJsonConfigFileContent, sys, createProgram, findConfigFile, ModuleKind, ModuleResolutionKind, readConfigFile, ScriptTarget } = pkg;
 
 const requiredCompilerOptions: CompilerOptions = {
 	noEmitOnError: false,


### PR DESCRIPTION
This change was tested against this repo:
https://github.com/dfinity/internet-identity

Without this fix, it would error as is described in the comment added to the `compile.mts` file. This is a result of me converting the CLI to ESM.

Strangely, this didn't error when I installed the package locally with `npm link` or a `file:` relative path. To confirm that the error is fixed by this change, I had to push up the build output to GitHub temporarily, and install it from that using [gitpkg](https://gitpkg.vercel.app). 

For future reference, this was the install URL I used to install this specific branch for the `lit-analyzer` sub-package:
  `"@jackolope/lit-analyzer": "https://gitpkg.now.sh/JackRobards/lit-analyzer/packages/lit-analyzer?fix-typescript-lit-analyzer-cli-support",`
