### PR TITLE
feat: Update `no-property-visibility-mismatch` rule to check for @state instead of @internalProperty

### DIFF
--- a/.changeset/flat-months-agree.md
+++ b/.changeset/flat-months-agree.md
@@ -1,0 +1,7 @@
+---
+"lit-analyzer-plugin": minor
+"@jackolope/ts-lit-plugin": minor
+"@jackolope/lit-analyzer": minor
+---
+
+feat: Update no-property-visibility-mismatch rule to check for @state decorator instead of deprecated @internalProperty decorator

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -10,8 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jackolope/ts-lit-plugin": "file:../packages/ts-lit-plugin",
-				"lit-element": "^2.3.1",
-				"lit-html": "^1.2.1"
+				"lit": "^3.2.1"
 			},
 			"devDependencies": {
 				"typescript": "~5.7.2"
@@ -22,17 +21,17 @@
 		},
 		"../packages/ts-lit-plugin": {
 			"name": "@jackolope/ts-lit-plugin",
-			"version": "2.0.2",
+			"version": "3.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"@jackolope/lit-analyzer": "^2.0.1",
-				"@jackolope/web-component-analyzer": "^2.0.0"
+				"@jackolope/lit-analyzer": "^3.0.0",
+				"@jackolope/web-component-analyzer": "^3.0.0"
 			},
 			"devDependencies": {
-				"@types/node": "^22.10.7",
+				"@types/node": "^22.12.0",
 				"esbuild": "^0.24.2",
 				"typescript": "^5.7.2",
-				"wireit": "^0.1.1"
+				"wireit": "^0.14.10"
 			},
 			"engines": {
 				"node": ">=18"
@@ -57,16 +56,57 @@
 			"resolved": "../packages/ts-lit-plugin",
 			"link": true
 		},
-		"node_modules/lit-element": {
-			"version": "2.5.1",
+		"node_modules/@lit-labs/ssr-dom-shim": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.3.0.tgz",
+			"integrity": "sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@lit/reactive-element": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+			"integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"lit-html": "^1.1.1"
+				"@lit-labs/ssr-dom-shim": "^1.2.0"
 			}
 		},
-		"node_modules/lit-html": {
-			"version": "1.4.1",
-			"license": "BSD-3-Clause"
+		"node_modules/@types/trusted-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+			"license": "MIT"
+		},
+		"node_modules/lit": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+			"integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit/reactive-element": "^2.0.4",
+				"lit-element": "^4.1.0",
+				"lit-html": "^3.2.0"
+			}
+		},
+		"node_modules/lit/node_modules/lit-element": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
+			"integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.2.0",
+				"@lit/reactive-element": "^2.0.4",
+				"lit-html": "^3.2.0"
+			}
+		},
+		"node_modules/lit/node_modules/lit-html": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+			"integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@types/trusted-types": "^2.0.2"
+			}
 		},
 		"node_modules/typescript": {
 			"version": "5.7.2",

--- a/dev/package.json
+++ b/dev/package.json
@@ -2,10 +2,10 @@
 	"name": "dev",
 	"version": "1.0.0",
 	"description": "",
+	"type": "module",
 	"dependencies": {
-		"lit-element": "^2.3.1",
-		"lit-html": "^1.2.1",
-		"@jackolope/ts-lit-plugin": "file:../packages/ts-lit-plugin"
+		"@jackolope/ts-lit-plugin": "file:../packages/ts-lit-plugin",
+		"lit": "^3.2.1"
 	},
 	"devDependencies": {
 		"typescript": "~5.7.2"

--- a/dev/src/my-element-1.ts
+++ b/dev/src/my-element-1.ts
@@ -1,13 +1,14 @@
-import { customElement, html, LitElement, property, internalProperty } from "lit-element";
+import { html, LitElement } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
 import "./my-element-2";
 
 @customElement("my-element")
 export class MyElement extends LitElement {
 	@property({ attribute: "hell>o" }) test: number | undefined;
 
-	@property({ type: Date }) test2: number | undefined;
+	@property({ type: Date }) private test2: number | undefined;
 
-	@internalProperty() internal: number | undefined;
+	@state() internal: number | undefined;
 
 	static get observedAttributes() {
 		return ["this is a test", "testing"];

--- a/docs/readme/rules.md
+++ b/docs/readme/rules.md
@@ -47,7 +47,7 @@ Each rule can have severity of `off`, `warning` or `error`. You can toggle rules
 | [no-incompatible-property-type](#-no-incompatible-property-type) | When using the @property decorator in Typescript, the property option `type` is checked against the declared property Typescript type | warn | error |
 | [no-invalid-attribute-name](#-no-invalid-attribute-name)         | When using the property option `attribute`, the value is checked to make sure it's a valid attribute name. | error | error |
 | [no-invalid-tag-name](#-no-invalid-tag-name)                     | When defining a custom element the tag name is checked to make sure it's valid. | error | error |
-| [no-property-visibility-mismatch](#no-property-visibility-mismatch) | This rule will ensure public properties use `@property` and non-public properties use `@internalProperty`. | off | warn |
+| [no-property-visibility-mismatch](#no-property-visibility-mismatch) | This rule will ensure public properties use `@property` and non-public properties use `@state`. | off | warn |
 
 **Validating CSS**
 
@@ -565,11 +565,11 @@ customElements.define("correct-element-name", MyElement);
 
 When using the `@property` decorator, your property should be publicly visible,
 expected to be exposed to consumers of the element. Private and protected
-properties however, should make use of the `@internalProperty` decorator
+properties however, should make use of the `@state` decorator
 instead.
 
 This rule will ensure public properties use `@property` and non-public
-properties use `@internalProperty`.
+properties use `@state`.
 
 The following example is considered a warning:
 

--- a/packages/lit-analyzer/README.md
+++ b/packages/lit-analyzer/README.md
@@ -120,7 +120,7 @@ Each rule can have severity of `off`, `warning` or `error`. You can toggle rules
 | [no-incompatible-property-type](#-no-incompatible-property-type) | When using the @property decorator in Typescript, the property option `type` is checked against the declared property Typescript type | warn | error |
 | [no-invalid-attribute-name](#-no-invalid-attribute-name)         | When using the property option `attribute`, the value is checked to make sure it's a valid attribute name. | error | error |
 | [no-invalid-tag-name](#-no-invalid-tag-name)                     | When defining a custom element the tag name is checked to make sure it's valid. | error | error |
-| [no-property-visibility-mismatch](#no-property-visibility-mismatch) | This rule will ensure public properties use `@property` and non-public properties use `@internalProperty`. | off | warn |
+| [no-property-visibility-mismatch](#no-property-visibility-mismatch) | This rule will ensure public properties use `@property` and non-public properties use `@state`. | off | warn |
 
 **Validating CSS**
 
@@ -638,11 +638,11 @@ customElements.define("correct-element-name", MyElement);
 
 When using the `@property` decorator, your property should be publicly visible,
 expected to be exposed to consumers of the element. Private and protected
-properties however, should make use of the `@internalProperty` decorator
+properties however, should make use of the `@state` decorator
 instead.
 
 This rule will ensure public properties use `@property` and non-public
-properties use `@internalProperty`.
+properties use `@state`.
 
 The following example is considered a warning:
 

--- a/packages/lit-analyzer/src/lib/rules/no-property-visibility-mismatch.ts
+++ b/packages/lit-analyzer/src/lib/rules/no-property-visibility-mismatch.ts
@@ -56,7 +56,7 @@ const rule: RuleModule = {
 				message: `'${member.propName}' is marked as an internal property (@state) but is publicly accessible.`,
 				...(inJsFile
 					? {
-							// We are in Javascript context. Add "@properted" or "@private" JSDoc
+							// We are in Javascript context. Add "@protected" or "@private" JSDoc
 						}
 					: {
 							// We are in Typescript context. Add "protected" or "private" keyword
@@ -116,6 +116,11 @@ const rule: RuleModule = {
 
 		// Handle cases where @property decorator is used, but the property is not public
 		else if (hasPropertyDecorator && member.visibility !== "public") {
+			// If the Lit `state` option is set on the decorator, then that is also considered valid
+			if (member.meta?.state) {
+				return;
+			}
+
 			context.report({
 				location: rangeFromNode(decoratorIdentifier),
 				message: `'${member.propName}' is not publicly accessible but is marked as a public property (@property).`,

--- a/packages/lit-analyzer/src/lib/rules/no-property-visibility-mismatch.ts
+++ b/packages/lit-analyzer/src/lib/rules/no-property-visibility-mismatch.ts
@@ -44,16 +44,16 @@ const rule: RuleModule = {
 
 		// Get the decorator of interest
 		const decoratorName = decoratorIdentifier.text;
-		const hasInternalDecorator = decoratorName === "internalProperty";
+		const hasInternalDecorator = decoratorName === "state";
 		const hasPropertyDecorator = decoratorName === "property";
 
-		// Handle cases where @internalProperty decorator is used, but the property is public
+		// Handle cases where @state decorator is used, but the property is public
 		if (hasInternalDecorator && (member.visibility === "public" || member.visibility == null)) {
 			const inJsFile = context.file.fileName.endsWith(".js");
 
 			context.report({
 				location: rangeFromNode(decoratorIdentifier),
-				message: `'${member.propName}' is marked as an internal property (@internalProperty) but is publicly accessible.`,
+				message: `'${member.propName}' is marked as an internal property (@state) but is publicly accessible.`,
 				...(inJsFile
 					? {
 							// We are in Javascript context. Add "@properted" or "@private" JSDoc
@@ -119,10 +119,10 @@ const rule: RuleModule = {
 			context.report({
 				location: rangeFromNode(decoratorIdentifier),
 				message: `'${member.propName}' is not publicly accessible but is marked as a public property (@property).`,
-				fixMessage: "Use the '@internalProperty' decorator instead?",
+				fixMessage: "Use the '@state' decorator instead?",
 				fix: () => {
 					// Return a code action that can replace the identifier of the decorator
-					const newText = `internalProperty`;
+					const newText = `state`;
 
 					// Change identifier to "internal property"
 					const actions: RuleFixAction[] = [
@@ -139,9 +139,9 @@ const rule: RuleModule = {
 					);
 
 					if (objectLiteralNode != null) {
-						// Remove the configuration if the config doesn't have any shared properties with the "internalProperty" config
-						const internalPropertyConfigProperties = ["hasChanged"];
-						if (!objectLiteralNode.properties?.some(propertyNode => internalPropertyConfigProperties.includes(propertyNode.name?.getText() || ""))) {
+						// Remove the configuration if the config doesn't have any shared properties with the "state" config
+						const stateConfigProperties = ["hasChanged"];
+						if (!objectLiteralNode.properties?.some(propertyNode => stateConfigProperties.includes(propertyNode.name?.getText() || ""))) {
 							actions.push({
 								kind: "changeRange",
 								range: rangeFromNode(objectLiteralNode),

--- a/packages/lit-analyzer/src/test/rules/no-property-visibility-mismatch.ts
+++ b/packages/lit-analyzer/src/test/rules/no-property-visibility-mismatch.ts
@@ -8,16 +8,14 @@ function makeTestElement({ properties }: { properties?: Array<{ visibility: stri
 		fileName: "my-element.ts",
 		text: `
 		class MyElement extends HTMElement {
-			${(properties || [])
-				.map(({ name, visibility, internal }) => `@${internal ? "internalProperty" : "property"}() ${visibility} ${name}: any;`)
-				.join("\n")}
+			${(properties || []).map(({ name, visibility, internal }) => `@${internal ? "state" : "property"}() ${visibility} ${name}: any;`).join("\n")}
 		};
 		customElements.define("my-element", MyElement);
 		`
 	};
 }
 
-tsTest("Report public @internalProperty properties", t => {
+tsTest("Report public @state properties", t => {
 	const { diagnostics } = getDiagnostics(
 		makeTestElement({
 			properties: [{ name: "foo", visibility: "public", internal: true }]

--- a/packages/lit-analyzer/src/test/rules/no-property-visibility-mismatch.ts
+++ b/packages/lit-analyzer/src/test/rules/no-property-visibility-mismatch.ts
@@ -2,6 +2,7 @@ import { getDiagnostics } from "../helpers/analyze.js";
 import { hasDiagnostic, hasNoDiagnostics } from "../helpers/assert.js";
 import { tsTest } from "../helpers/ts-test.js";
 import type { TestFile } from "../helpers/compile-files.js";
+import { makeElement } from "../helpers/generate-test-file.js";
 
 function makeTestElement({ properties }: { properties?: Array<{ visibility: string; name: string; internal: boolean }> }): TestFile {
 	return {
@@ -46,6 +47,26 @@ tsTest("Don't report regular public properties", t => {
 		}),
 		{
 			rules: { "no-property-visibility-mismatch": true }
+		}
+	);
+	hasNoDiagnostics(t, diagnostics);
+});
+
+tsTest("Don't report private @property properties with `state` true", t => {
+	const { diagnostics } = getDiagnostics(
+		[
+			makeElement({
+				properties: [
+					`@property({ state: true })
+					private foo: string;`
+				],
+				fullPropertyDeclaration: true
+			})
+		],
+		{
+			rules: {
+				"no-property-visibility-mismatch": true
+			}
 		}
 	);
 	hasNoDiagnostics(t, diagnostics);

--- a/packages/ts-lit-plugin/README.md
+++ b/packages/ts-lit-plugin/README.md
@@ -145,7 +145,7 @@ Each rule can have severity of `off`, `warning` or `error`. You can toggle rules
 | [no-incompatible-property-type](#-no-incompatible-property-type) | When using the @property decorator in Typescript, the property option `type` is checked against the declared property Typescript type | warn | error |
 | [no-invalid-attribute-name](#-no-invalid-attribute-name)         | When using the property option `attribute`, the value is checked to make sure it's a valid attribute name. | error | error |
 | [no-invalid-tag-name](#-no-invalid-tag-name)                     | When defining a custom element the tag name is checked to make sure it's valid. | error | error |
-| [no-property-visibility-mismatch](#no-property-visibility-mismatch) | This rule will ensure public properties use `@property` and non-public properties use `@internalProperty`. | off | warn |
+| [no-property-visibility-mismatch](#no-property-visibility-mismatch) | This rule will ensure public properties use `@property` and non-public properties use `@state`. | off | warn |
 
 **Validating CSS**
 
@@ -663,11 +663,11 @@ customElements.define("correct-element-name", MyElement);
 
 When using the `@property` decorator, your property should be publicly visible,
 expected to be exposed to consumers of the element. Private and protected
-properties however, should make use of the `@internalProperty` decorator
+properties however, should make use of the `@state` decorator
 instead.
 
 This rule will ensure public properties use `@property` and non-public
-properties use `@internalProperty`.
+properties use `@state`.
 
 The following example is considered a warning:
 

--- a/packages/vscode-lit-plugin/README.md
+++ b/packages/vscode-lit-plugin/README.md
@@ -89,7 +89,7 @@ Each rule can have severity of `off`, `warning` or `error`. You can toggle rules
 | [no-incompatible-property-type](#-no-incompatible-property-type) | When using the @property decorator in Typescript, the property option `type` is checked against the declared property Typescript type | warn | error |
 | [no-invalid-attribute-name](#-no-invalid-attribute-name)         | When using the property option `attribute`, the value is checked to make sure it's a valid attribute name. | error | error |
 | [no-invalid-tag-name](#-no-invalid-tag-name)                     | When defining a custom element the tag name is checked to make sure it's valid. | error | error |
-| [no-property-visibility-mismatch](#no-property-visibility-mismatch) | This rule will ensure public properties use `@property` and non-public properties use `@internalProperty`. | off | warn |
+| [no-property-visibility-mismatch](#no-property-visibility-mismatch) | This rule will ensure public properties use `@property` and non-public properties use `@state`. | off | warn |
 
 **Validating CSS**
 
@@ -607,11 +607,11 @@ customElements.define("correct-element-name", MyElement);
 
 When using the `@property` decorator, your property should be publicly visible,
 expected to be exposed to consumers of the element. Private and protected
-properties however, should make use of the `@internalProperty` decorator
+properties however, should make use of the `@state` decorator
 instead.
 
 This rule will ensure public properties use `@property` and non-public
-properties use `@internalProperty`.
+properties use `@state`.
 
 The following example is considered a warning:
 


### PR DESCRIPTION
The `@internalProperty` decorator was deprecated and renamed to `@state`. It seems like this rule was just not updated to reflect this when that change was made to Lit.

Fixes #132