### PR TITLE
chore: Update david-dm badge links to new URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 		<a href="https://marketplace.visualstudio.com/items?itemName=jackolope.lit-analyzer-plugin"><img alt="Downloads per Month" src="https://vsmarketplacebadges.dev/downloads-short/jackolope.lit-analyzer-plugin.svg?label=vscode-lit-plugin" height="20"/></a>
 <a href="https://www.npmjs.com/package/@jackolope/lit-analyzer"><img alt="Downloads per Month" src="https://img.shields.io/npm/dm/@jackolope/lit-analyzer.svg?label=@jackolope/lit-analyzer" height="20"/></a>
 <a href="https://www.npmjs.com/package/@jackolope/ts-lit-plugin"><img alt="Downloads per Month" src="https://img.shields.io/npm/dm/@jackolope/ts-lit-plugin.svg?label=@jackolope/ts-lit-plugin" height="20"/></a>
-<a href="https://github.com/JackRobards/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/JackRobards/@jackolope/lit-analyzer" height="20"/></a>
-	</p>
+<a href="https://github.com/JackRobards/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/JackRobards/lit-analyzer.svg" height="20"/></a>
+</p>
 
 This mono-repository consists of the following tools:
 

--- a/packages/lit-analyzer/README.md
+++ b/packages/lit-analyzer/README.md
@@ -6,12 +6,10 @@
 
 <br />
 
-<p align="center">
-		<a href="https://npmcharts.com/compare/@jackolope/lit-analyzer?minimal=true"><img alt="Downloads per month" src="https://img.shields.io/npm/dm/@jackolope/lit-analyzer.svg" height="20"/></a>
+<a href="https://npmcharts.com/compare/@jackolope/lit-analyzer?minimal=true"><img alt="Downloads per month" src="https://img.shields.io/npm/dm/@jackolope/lit-analyzer.svg" height="20"/></a>
 <a href="https://www.npmjs.com/package/@jackolope/lit-analyzer"><img alt="NPM Version" src="https://img.shields.io/npm/v/@jackolope/lit-analyzer.svg" height="20"/></a>
-<a href="https://david-dm.org/JackRobards/lit-analyzer"><img alt="Dependencies" src="https://img.shields.io/david/JackRobards/lit-analyzer.svg" height="20"/></a>
+[![Dependencies](https://img.shields.io/librariesio/release/npm/@jackolope/lit-analyzer)](https://libraries.io/npm/@jackolope/lit-analyzer)
 <a href="https://github.com/JackRobards/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/JackRobards/lit-analyzer.svg" height="20"/></a>
-	</p>
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png)](#installation)
 

--- a/packages/ts-lit-plugin/README.md
+++ b/packages/ts-lit-plugin/README.md
@@ -6,12 +6,10 @@
 
 <br />
 
-<p align="center">
-		<a href="https://npmcharts.com/compare/@jackolope/ts-lit-plugin?minimal=true"><img alt="Downloads per month" src="https://img.shields.io/npm/dm/@jackolope/ts-lit-plugin.svg" height="20"/></a>
+<a href="https://npmcharts.com/compare/@jackolope/ts-lit-plugin?minimal=true"><img alt="Downloads per month" src="https://img.shields.io/npm/dm/@jackolope/ts-lit-plugin.svg" height="20"/></a>
 <a href="https://www.npmjs.com/package/@jackolope/ts-lit-plugin"><img alt="NPM Version" src="https://img.shields.io/npm/v/@jackolope/ts-lit-plugin.svg" height="20"/></a>
-<a href="https://david-dm.org/JackRobards/lit-analyzer"><img alt="Dependencies" src="https://img.shields.io/david/JackRobards/lit-analyzer.svg" height="20"/></a>
+[![Dependencies](https://img.shields.io/librariesio/release/npm/@jackolope/ts-lit-plugin)](https://libraries.io/npm/@jackolope/ts-lit-plugin)
 <a href="https://github.com/JackRobards/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/JackRobards/lit-analyzer.svg" height="20"/></a>
-	</p>
 
 <p align="center">
   <img src="https://user-images.githubusercontent.com/5372940/62078476-02c1ec00-b24d-11e9-8de5-1322012cbde2.gif" alt="Lit plugin GIF"/>

--- a/packages/vscode-lit-plugin/README.md
+++ b/packages/vscode-lit-plugin/README.md
@@ -15,7 +15,7 @@
 [![](https://vsmarketplacebadges.dev/downloads-short/jackolope.lit-analyzer-plugin.svg)](https://marketplace.visualstudio.com/items?itemName=jackolope.lit-analyzer-plugin)
 [![](https://vsmarketplacebadges.dev/rating-short/jackolope.lit-analyzer-plugin.svg)](https://marketplace.visualstudio.com/items?itemName=jackolope.lit-analyzer-plugin)
 <a href="https://opensource.org/licenses/MIT"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-green.svg" height="20"></img></a>
-<a href="https://david-dm.org/JackRobards/lit-analyzer"><img alt="Dependencies" src="https://img.shields.io/david/JackRobards/lit-analyzer.svg?color=green" height="20"/></a>
+[![Dependencies](https://img.shields.io/librariesio/release/npm/@jackolope/lit-analyzer)](https://libraries.io/npm/@jackolope/lit-analyzer)
 <a href="https://github.com/JackRobards/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/JackRobards/lit-analyzer.svg" height="20"/></a>
 
   <img src="https://user-images.githubusercontent.com/5372940/62078476-02c1ec00-b24d-11e9-8de5-1322012cbde2.gif" alt="Lit plugin GIF"/>

--- a/packages/vscode-lit-plugin/readme/header.md
+++ b/packages/vscode-lit-plugin/readme/header.md
@@ -8,7 +8,7 @@
 [![](https://vsmarketplacebadges.dev/downloads-short/jackolope.lit-analyzer-plugin.svg)](https://marketplace.visualstudio.com/items?itemName=jackolope.lit-analyzer-plugin)
 [![](https://vsmarketplacebadges.dev/rating-short/jackolope.lit-analyzer-plugin.svg)](https://marketplace.visualstudio.com/items?itemName=jackolope.lit-analyzer-plugin)
 <a href="https://opensource.org/licenses/MIT"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-green.svg" height="20"></img></a>
-<a href="https://david-dm.org/JackRobards/lit-analyzer"><img alt="Dependencies" src="https://img.shields.io/david/JackRobards/lit-analyzer.svg?color=green" height="20"/></a>
+[![Dependencies](https://img.shields.io/librariesio/release/npm/@jackolope/lit-analyzer)](https://libraries.io/npm/@jackolope/lit-analyzer)
 <a href="https://github.com/JackRobards/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/JackRobards/lit-analyzer.svg" height="20"/></a>
 
   <img src="https://user-images.githubusercontent.com/5372940/62078476-02c1ec00-b24d-11e9-8de5-1322012cbde2.gif" alt="Lit plugin GIF"/>

--- a/packages/web-component-analyzer/README.md
+++ b/packages/web-component-analyzer/README.md
@@ -1,11 +1,9 @@
 <h1 align="center">web-component-analyzer</h1>
 
-<p align="center">
-	<a href="https://npmcharts.com/compare/@jackolope/web-component-analyzer?minimal=true"><img alt="Downloads per month" src="https://img.shields.io/npm/dm/@jackolope/web-component-analyzer.svg" height="20"/></a>
-	<a href="https://www.npmjs.com/package/@jackolope/web-component-analyzer"><img alt="NPM Version" src="https://img.shields.io/npm/v/@jackolope/web-component-analyzer.svg" height="20"/></a>
-	<a href="https://david-dm.org/JackRobards/lit-analyzer"><img alt="Dependencies" src="https://img.shields.io/david/JackRobards/lit-analyzer.svg" height="20"/></a>
-	<a href="https://github.com/JackRobards/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/JackRobards/lit-analyzer.svg" height="20"/></a>
-</p>
+<a href="https://npmcharts.com/compare/@jackolope/web-component-analyzer?minimal=true"><img alt="Downloads per month" src="https://img.shields.io/npm/dm/@jackolope/web-component-analyzer.svg" height="20"/></a>
+<a href="https://www.npmjs.com/package/@jackolope/web-component-analyzer"><img alt="NPM Version" src="https://img.shields.io/npm/v/@jackolope/web-component-analyzer.svg" height="20"/></a>
+[![Dependencies](https://img.shields.io/librariesio/release/npm/@jackolope/web-component-analyzer)](https://libraries.io/npm/@jackolope/web-component-analyzer)
+<a href="https://github.com/JackRobards/lit-analyzer/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/JackRobards/lit-analyzer.svg" height="20"/></a>
 
 <p align="center">
   <img src="https://user-images.githubusercontent.com/5372940/68087781-1044ce80-fe59-11e9-969c-4234f9287f1b.gif" alt="Web component analyzer GIF"/>


### PR DESCRIPTION
david-dm badge urls do not work consistently, so switching these over to libraries,io when I have some time to look into it.