### PR TITLE
Fix a few minor things around the plugin

### DIFF
--- a/.changeset/eager-lies-judge.md
+++ b/.changeset/eager-lies-judge.md
@@ -1,0 +1,7 @@
+---
+"lit-analyzer-plugin": patch
+"@jackolope/ts-lit-plugin": patch
+"@jackolope/lit-analyzer": patch
+---
+
+fix: Make no-incompatible-type-binding rule ignore undefined when binding a property (with .) on union types

--- a/.changeset/fast-ways-prove.md
+++ b/.changeset/fast-ways-prove.md
@@ -1,0 +1,7 @@
+---
+"lit-analyzer-plugin": patch
+"@jackolope/ts-lit-plugin": patch
+"@jackolope/lit-analyzer": patch
+---
+
+fix: Turn no-nullable-attribute-binding off by default as it is no longer relevant in newer Lit versions. It can still be turned on via configuration if so desired.

--- a/.changeset/vast-jars-sleep.md
+++ b/.changeset/vast-jars-sleep.md
@@ -1,0 +1,7 @@
+---
+"lit-analyzer-plugin": patch
+"@jackolope/ts-lit-plugin": patch
+"@jackolope/lit-analyzer": patch
+---
+
+fix: Make no-incompatible-property-type rule ignor e @property decorators with a `state: true` option in the same way as it ignores `attribute: false`

--- a/.changeset/violet-hats-decide.md
+++ b/.changeset/violet-hats-decide.md
@@ -1,0 +1,5 @@
+---
+"@jackolope/ts-lit-plugin": patch
+---
+
+chore: Support configuring in the tsconfig.json by the name ts-lit-plugin as well for compatibility with the original.

--- a/docs/readme/rules.md
+++ b/docs/readme/rules.md
@@ -34,7 +34,7 @@ Each rule can have severity of `off`, `warning` or `error`. You can toggle rules
 | [no-noncallable-event-binding](#-no-noncallable-event-binding)   | Disallow event listener bindings with a noncallable type. | error | error |
 | [no-boolean-in-attribute-binding](#-no-boolean-in-attribute-binding) | Disallow attribute bindings with a boolean type. | error | error |
 | [no-complex-attribute-binding](#-no-complex-attribute-binding)   | Disallow attribute bindings with a complex type. | error | error |
-| [no-nullable-attribute-binding](#-no-nullable-attribute-binding) | Disallow attribute bindings with nullable types such as "null" or "undefined".  | error | error |
+| [no-nullable-attribute-binding](#-no-nullable-attribute-binding) | Disallow attribute bindings with nullable types such as "null" or "undefined". This is not needed in newer versions of Lit, but can still be configured if desired.  | off | off |
 | [no-incompatible-type-binding](#-no-incompatible-type-binding)   | Disallow incompatible type in bindings.  | error | error |
 | [no-invalid-directive-binding](#-no-invalid-directive-binding)   | Disallow using built-in directives in unsupported bindings. | error | error |
 | [no-unintended-mixed-binding](#-no-unintended-mixed-binding)   | Disallow mixed value bindings where a character `'`, `"`, `}` or `/` is unintentionally included in the binding. | warning | warning |
@@ -355,6 +355,8 @@ html`<my-list .listItems="${listItems}"></my-list>`
 ```
 
 #### ⭕️ no-nullable-attribute-binding
+
+This is not needed in newer versions of Lit, but can still be configured if desired.
 
 Binding `undefined` or `null` in an attribute binding will result in binding the string "undefined" or "null". Here you should probably wrap your expression in the "ifDefined" directive.
 

--- a/packages/lit-analyzer/README.md
+++ b/packages/lit-analyzer/README.md
@@ -107,7 +107,7 @@ Each rule can have severity of `off`, `warning` or `error`. You can toggle rules
 | [no-noncallable-event-binding](#-no-noncallable-event-binding)   | Disallow event listener bindings with a noncallable type. | error | error |
 | [no-boolean-in-attribute-binding](#-no-boolean-in-attribute-binding) | Disallow attribute bindings with a boolean type. | error | error |
 | [no-complex-attribute-binding](#-no-complex-attribute-binding)   | Disallow attribute bindings with a complex type. | error | error |
-| [no-nullable-attribute-binding](#-no-nullable-attribute-binding) | Disallow attribute bindings with nullable types such as "null" or "undefined".  | error | error |
+| [no-nullable-attribute-binding](#-no-nullable-attribute-binding) | Disallow attribute bindings with nullable types such as "null" or "undefined". This is not needed in newer versions of Lit, but can still be configured if desired.   | off | off |
 | [no-incompatible-type-binding](#-no-incompatible-type-binding)   | Disallow incompatible type in bindings.  | error | error |
 | [no-invalid-directive-binding](#-no-invalid-directive-binding)   | Disallow using built-in directives in unsupported bindings. | error | error |
 | [no-unintended-mixed-binding](#-no-unintended-mixed-binding)   | Disallow mixed value bindings where a character `'`, `"`, `}` or `/` is unintentionally included in the binding. | warning | warning |
@@ -428,6 +428,8 @@ html`<my-list .listItems="${listItems}"></my-list>`
 ```
 
 #### ⭕️ no-nullable-attribute-binding
+
+This is not needed in newer versions of Lit, but can still be configured if desired.
 
 Binding `undefined` or `null` in an attribute binding will result in binding the string "undefined" or "null". Here you should probably wrap your expression in the "ifDefined" directive.
 

--- a/packages/lit-analyzer/src/lib/analyze/lit-analyzer-config.ts
+++ b/packages/lit-analyzer/src/lib/analyze/lit-analyzer-config.ts
@@ -48,7 +48,7 @@ const DEFAULT_RULES_SEVERITY: Record<LitAnalyzerRuleId, [LitAnalyzerRuleSeverity
 	"no-noncallable-event-binding": ["error", "error"],
 	"no-boolean-in-attribute-binding": ["error", "error"],
 	"no-complex-attribute-binding": ["error", "error"],
-	"no-nullable-attribute-binding": ["error", "error"],
+	"no-nullable-attribute-binding": ["off", "off"],
 	"no-incompatible-type-binding": ["error", "error"],
 	"no-invalid-directive-binding": ["error", "error"],
 	"no-incompatible-property-type": ["warn", "error"],

--- a/packages/lit-analyzer/src/lib/rules/no-incompatible-property-type.ts
+++ b/packages/lit-analyzer/src/lib/rules/no-incompatible-property-type.ts
@@ -166,7 +166,7 @@ function validateLitPropertyConfig(
 	}
 
 	// If no type has been specified, suggest what to use as the @property type
-	else if (litConfig.attribute !== false) {
+	else if (litConfig.attribute !== false && !litConfig.state) {
 		// Don't do anything if there are multiple possibilities for a type.
 		if (isAssignableTo("ANY")) {
 			return;

--- a/packages/lit-analyzer/src/lib/rules/util/type/is-assignable-in-property-binding.ts
+++ b/packages/lit-analyzer/src/lib/rules/util/type/is-assignable-in-property-binding.ts
@@ -18,7 +18,10 @@ export function isAssignableInPropertyBinding(
 		return securitySystemResult;
 	}
 
-	if (!isAssignableToType({ typeA, typeB }, context)) {
+	// Exclude `undefined` from union type checks
+	const filteredTypeB = typeB.kind === "UNION" ? { ...typeB, types: typeB.types.filter(type => type.kind !== "UNDEFINED") } : typeB;
+
+	if (!isAssignableToType({ typeA, typeB: filteredTypeB }, context)) {
 		context.report({
 			location: rangeFromHtmlNodeAttr(htmlAttr),
 			message: `Type '${typeToString(typeB)}' is not assignable to '${typeToString(typeA)}'`

--- a/packages/lit-analyzer/src/test/rules/no-incompatible-property-type.ts
+++ b/packages/lit-analyzer/src/test/rules/no-incompatible-property-type.ts
@@ -97,3 +97,83 @@ tsTest("'no-incompatible-property-type' is not emitted for number types with Num
 
 	hasNoDiagnostics(t, diagnostics);
 });
+
+tsTest("'no-incompatible-property-type' is not emitted for non-string types with attribute: false", t => {
+	const { diagnostics } = getDiagnostics(
+		`
+  /**
+   * @element
+	 */
+	class MyElement extends LitElement {
+		@property({ attribute: false }) color: number;
+	}
+	`,
+		{ rules: { "no-incompatible-property-type": "on" } }
+	);
+
+	hasNoDiagnostics(t, diagnostics);
+});
+
+tsTest("'no-incompatible-property-type' is emitted for non-string types with attribute: true", t => {
+	const { diagnostics } = getDiagnostics(
+		`
+  /**
+   * @element
+	 */
+	class MyElement extends LitElement {
+		@property({ attribute: true }) color: number;
+	}
+	`,
+		{ rules: { "no-incompatible-property-type": "on" } }
+	);
+
+	hasDiagnostic(t, diagnostics, "no-incompatible-property-type");
+});
+
+tsTest("'no-incompatible-property-type' is emitted for non-string types with custom attribute name configured", t => {
+	const { diagnostics } = getDiagnostics(
+		`
+  /**
+   * @element
+	 */
+	class MyElement extends LitElement {
+		@property({ attribute: 'attribute-name' }) color: number;
+	}
+	`,
+		{ rules: { "no-incompatible-property-type": "on" } }
+	);
+
+	hasDiagnostic(t, diagnostics, "no-incompatible-property-type");
+});
+
+tsTest("'no-incompatible-property-type' is not emitted for non-string types with state: true", t => {
+	const { diagnostics } = getDiagnostics(
+		`
+  /**
+   * @element
+	 */
+	class MyElement extends LitElement {
+		@property({ state: true }) color: number;
+	}
+	`,
+		{ rules: { "no-incompatible-property-type": "on" } }
+	);
+
+	hasNoDiagnostics(t, diagnostics);
+});
+
+tsTest("'no-incompatible-property-type' is emitted for non-string types with state: false", t => {
+	const { diagnostics } = getDiagnostics(
+		`
+  /**
+   * @element
+	 */
+	class MyElement extends LitElement {
+		@property({ state: false }) color: number;
+	}
+	`,
+		{ rules: { "no-incompatible-property-type": "on" } }
+	);
+
+	hasDiagnostic(t, diagnostics, "no-incompatible-property-type");
+});

--- a/packages/lit-analyzer/src/test/rules/no-incompatible-type-binding.ts
+++ b/packages/lit-analyzer/src/test/rules/no-incompatible-type-binding.ts
@@ -217,6 +217,30 @@ tsTest("Property binding: Boolean type expression is not assignable to boolean p
 	hasNoDiagnostics(t, diagnostics);
 });
 
+tsTest("Property binding: Type expression correctly removes 'undefined' from the type union 1", t => {
+	const { diagnostics } = getDiagnostics([
+		makeElement({ properties: ["foo = ''"] }),
+		'html`<my-element .foo="${"bar" as string | undefined}"></my-element>`'
+	]);
+	hasNoDiagnostics(t, diagnostics);
+});
+
+tsTest("Property binding: Type expression correctly removes 'undefined' from the type union 2", t => {
+	const { diagnostics } = getDiagnostics([
+		makeElement({ properties: ["foo: string | number = 0"] }),
+		'html`<my-element .foo="${5 as string | number | undefined}"></my-element>`'
+	]);
+	hasNoDiagnostics(t, diagnostics);
+});
+
+tsTest("Property binding: Type expression correctly reports a type union that is only partially met", t => {
+	const { diagnostics } = getDiagnostics([
+		makeElement({ properties: ["foo: number = 0"] }),
+		'html`<my-element .foo="${"bar" as string | number}"></my-element>`'
+	]);
+	hasDiagnostic(t, diagnostics, "no-incompatible-type-binding");
+});
+
 tsTest("Attribute binding: 'ifDefined' directive correctly removes 'undefined' from the type union 1", t => {
 	const { diagnostics } = getDiagnostics('type ifDefined = Function; html`<input maxlength="${ifDefined({} as number | undefined)}" />`');
 	hasNoDiagnostics(t, diagnostics);

--- a/packages/lit-analyzer/src/test/rules/no-nullable-attribute-binding.ts
+++ b/packages/lit-analyzer/src/test/rules/no-nullable-attribute-binding.ts
@@ -3,46 +3,55 @@ import { hasDiagnostic, hasNoDiagnostics } from "../helpers/assert.js";
 import { makeElement } from "../helpers/generate-test-file.js";
 import { tsTest } from "../helpers/ts-test.js";
 
-tsTest("Cannot assign 'undefined' in attribute binding", t => {
-	const { diagnostics } = getDiagnostics('html`<input maxlength="${{} as number | undefined}" />`');
+tsTest("'no-nullable-attribute-binding' Cannot assign 'undefined' in attribute binding", t => {
+	const { diagnostics } = getDiagnostics('html`<input maxlength="${{} as number | undefined}" />`', {
+		rules: { "no-nullable-attribute-binding": true }
+	});
 	hasDiagnostic(t, diagnostics, "no-nullable-attribute-binding");
 });
 
-tsTest("Can assign 'undefined' in property binding", t => {
-	const { diagnostics } = getDiagnostics([
-		makeElement({ slots: ["foo: number | undefined"] }),
-		'html`<my-element .foo="${{} as number | undefined}"></my-element>`'
-	]);
+tsTest("'no-nullable-attribute-binding' Can assign 'undefined' in property binding", t => {
+	const { diagnostics } = getDiagnostics(
+		[makeElement({ slots: ["foo: number | undefined"] }), 'html`<my-element .foo="${{} as number | undefined}"></my-element>`'],
+		{ rules: { "no-nullable-attribute-binding": true } }
+	);
 	hasNoDiagnostics(t, diagnostics);
 });
 
-tsTest("Cannot assign 'null' in attribute binding", t => {
-	const { diagnostics } = getDiagnostics('html`<input maxlength="${{} as number | null}" />`');
+tsTest("'no-nullable-attribute-binding' Cannot assign 'null' in attribute binding", t => {
+	const { diagnostics } = getDiagnostics('html`<input maxlength="${{} as number | null}" />`', { rules: { "no-nullable-attribute-binding": true } });
 	hasDiagnostic(t, diagnostics, "no-nullable-attribute-binding");
 });
 
-tsTest("Can assign 'null' in property binding", t => {
-	const { diagnostics } = getDiagnostics('html`<input .selectionEnd="${{} as number | null}" />`');
+tsTest("'no-nullable-attribute-binding' Can assign 'null' in property binding", t => {
+	const { diagnostics } = getDiagnostics('html`<input .selectionEnd="${{} as number | null}" />`', {
+		rules: { "no-nullable-attribute-binding": true }
+	});
 	hasNoDiagnostics(t, diagnostics);
 });
 
-tsTest("Return type of `ifDefined` is not `null`", t => {
-	const { diagnostics } = getDiagnostics(`
+tsTest("'no-nullable-attribute-binding' Return type of `ifDefined` is not `null`", t => {
+	const { diagnostics } = getDiagnostics(
+		`
 		const ifDefined = <T>(x: T) => x ?? "non-null";
 		html\`<input some-attribute="$\{ifDefined(Math.random() < 0.5 ? 123 : null)}" />\`;
-	`);
+	`,
+		{ rules: { "no-nullable-attribute-binding": true } }
+	);
 	hasNoDiagnostics(t, diagnostics);
 });
 
-tsTest("Message for 'null' in attribute detects null type correctly", t => {
-	const { diagnostics } = getDiagnostics('html`<input maxlength="${{} as number | null}" />`');
+tsTest("'no-nullable-attribute-binding' Message for 'null' in attribute detects null type correctly", t => {
+	const { diagnostics } = getDiagnostics('html`<input maxlength="${{} as number | null}" />`', { rules: { "no-nullable-attribute-binding": true } });
 	hasDiagnostic(t, diagnostics, "no-nullable-attribute-binding");
 
 	t.true(diagnostics[0].message.includes("can end up binding the string 'null'"));
 });
 
-tsTest("Message for 'undefined' in attribute detects undefined type correctly", t => {
-	const { diagnostics } = getDiagnostics('html`<input maxlength="${{} as number | undefined}" />`');
+tsTest("'no-nullable-attribute-binding' Message for 'undefined' in attribute detects undefined type correctly", t => {
+	const { diagnostics } = getDiagnostics('html`<input maxlength="${{} as number | undefined}" />`', {
+		rules: { "no-nullable-attribute-binding": true }
+	});
 	hasDiagnostic(t, diagnostics, "no-nullable-attribute-binding");
 
 	t.true(diagnostics[0].message.includes("can end up binding the string 'undefined'"));

--- a/packages/ts-lit-plugin/README.md
+++ b/packages/ts-lit-plugin/README.md
@@ -132,7 +132,7 @@ Each rule can have severity of `off`, `warning` or `error`. You can toggle rules
 | [no-noncallable-event-binding](#-no-noncallable-event-binding)   | Disallow event listener bindings with a noncallable type. | error | error |
 | [no-boolean-in-attribute-binding](#-no-boolean-in-attribute-binding) | Disallow attribute bindings with a boolean type. | error | error |
 | [no-complex-attribute-binding](#-no-complex-attribute-binding)   | Disallow attribute bindings with a complex type. | error | error |
-| [no-nullable-attribute-binding](#-no-nullable-attribute-binding) | Disallow attribute bindings with nullable types such as "null" or "undefined".  | error | error |
+| [no-nullable-attribute-binding](#-no-nullable-attribute-binding) | Disallow attribute bindings with nullable types such as "null" or "undefined". This is not needed in newer versions of Lit, but can still be configured if desired.  | off | off |
 | [no-incompatible-type-binding](#-no-incompatible-type-binding)   | Disallow incompatible type in bindings.  | error | error |
 | [no-invalid-directive-binding](#-no-invalid-directive-binding)   | Disallow using built-in directives in unsupported bindings. | error | error |
 | [no-unintended-mixed-binding](#-no-unintended-mixed-binding)   | Disallow mixed value bindings where a character `'`, `"`, `}` or `/` is unintentionally included in the binding. | warning | warning |
@@ -453,6 +453,8 @@ html`<my-list .listItems="${listItems}"></my-list>`
 ```
 
 #### ⭕️ no-nullable-attribute-binding
+
+This is not needed in newer versions of Lit, but can still be configured if desired.
 
 Binding `undefined` or `null` in an attribute binding will result in binding the string "undefined" or "null". Here you should probably wrap your expression in the "ifDefined" directive.
 

--- a/packages/ts-lit-plugin/README.md
+++ b/packages/ts-lit-plugin/README.md
@@ -64,6 +64,7 @@ You can configure this plugin through your `tsconfig.json`.
   "compilerOptions": {
     "plugins": [
       {
+				// Also supports the name `ts-lit-plugin` for compatibility with the original version
         "name": "@jackolope/ts-lit-plugin",
         "strict": true,
         "rules": {

--- a/packages/ts-lit-plugin/readme/config.md
+++ b/packages/ts-lit-plugin/readme/config.md
@@ -10,6 +10,7 @@ You can configure this plugin through your `tsconfig.json`.
   "compilerOptions": {
     "plugins": [
       {
+				// Also supports the name `ts-lit-plugin` for compatibility with the original version
         "name": "@jackolope/ts-lit-plugin",
         "strict": true,
         "rules": {

--- a/packages/ts-lit-plugin/src/index.ts
+++ b/packages/ts-lit-plugin/src/index.ts
@@ -112,12 +112,13 @@ export function init({ typescript }: { typescript: typeof ts }): tsServer.server
 
 /**
  * Resolves the nearest tsconfig.json and returns the configuration seed within the plugins section for "@jackolope/ts-lit-plugin"
+ * Also supports `ts-lit-plugin` to support code configured with the original ts-lit-plugin.
  */
 function readLitAnalyzerConfigFromCompilerOptions(compilerOptions: CompilerOptions): Partial<LitAnalyzerConfig> | undefined {
 	// Finds the plugin section
 	if ("plugins" in compilerOptions) {
 		const plugins = compilerOptions.plugins as ({ name: string } & Partial<LitAnalyzerConfig>)[];
-		const tsLitPluginOptions = plugins.find(plugin => plugin.name === "@jackolope/ts-lit-plugin");
+		const tsLitPluginOptions = plugins.find(plugin => plugin.name === "@jackolope/ts-lit-plugin" || plugin.name === "ts-lit-plugin");
 		if (tsLitPluginOptions != null) {
 			return tsLitPluginOptions;
 		}

--- a/packages/vscode-lit-plugin/README.md
+++ b/packages/vscode-lit-plugin/README.md
@@ -76,7 +76,7 @@ Each rule can have severity of `off`, `warning` or `error`. You can toggle rules
 | [no-noncallable-event-binding](#-no-noncallable-event-binding)   | Disallow event listener bindings with a noncallable type. | error | error |
 | [no-boolean-in-attribute-binding](#-no-boolean-in-attribute-binding) | Disallow attribute bindings with a boolean type. | error | error |
 | [no-complex-attribute-binding](#-no-complex-attribute-binding)   | Disallow attribute bindings with a complex type. | error | error |
-| [no-nullable-attribute-binding](#-no-nullable-attribute-binding) | Disallow attribute bindings with nullable types such as "null" or "undefined".  | error | error |
+| [no-nullable-attribute-binding](#-no-nullable-attribute-binding) | Disallow attribute bindings with nullable types such as "null" or "undefined". This is not needed in newer versions of Lit, but can still be configured if desired.  | off | off |
 | [no-incompatible-type-binding](#-no-incompatible-type-binding)   | Disallow incompatible type in bindings.  | error | error |
 | [no-invalid-directive-binding](#-no-invalid-directive-binding)   | Disallow using built-in directives in unsupported bindings. | error | error |
 | [no-unintended-mixed-binding](#-no-unintended-mixed-binding)   | Disallow mixed value bindings where a character `'`, `"`, `}` or `/` is unintentionally included in the binding. | warning | warning |
@@ -397,6 +397,8 @@ html`<my-list .listItems="${listItems}"></my-list>`
 ```
 
 #### ⭕️ no-nullable-attribute-binding
+
+This is not needed in newer versions of Lit, but can still be configured if desired.
 
 Binding `undefined` or `null` in an attribute binding will result in binding the string "undefined" or "null". Here you should probably wrap your expression in the "ifDefined" directive.
 


### PR DESCRIPTION
Changes:
- `no-nullable-attribute-binding` rule is now `off` by default on both the default and strict rulesets. Newer versions of Lit handle removing `null` or `undefined` in attribute bindings for you, so you do not need this rule unless you still are using an old Lit version. See this issue: https://github.com/runem/lit-analyzer/issues/253
- `no-incompatible-property-type` rule will now not report an error if `state:true` is configured using the `@property` decorator. This matches how the rule behaves for `attribute: false`, since they both indicate that this is not an attribute and so does not need a type converter.
- `no-incompatible-type-binding` now ignores `undefined` in union types when binding with a property (`.`). This is because there is no way to mark a property as `required` in Lit, so properties either need to treat the property as possibly `undefined` or set a default value. In practice there is no benefit to throwing an error if the only issue is that the property is maybe `undefined` in my experience.
- The VSCode extension (and `@jackolope/ts-lit-plugin` in general) will now also read in the config from the old name `ts-lit-plugin` . So if you open a repository that has `ts-lit-plugin` configured, then this plugin will use that config.