### PR TITLE
feat: Add support for `html.customData` setting

### DIFF
--- a/.changeset/cold-toys-leave.md
+++ b/.changeset/cold-toys-leave.md
@@ -1,0 +1,6 @@
+---
+"lit-analyzer-plugin": minor
+"@jackolope/lit-analyzer": minor
+---
+
+feat: Add support for VSCode's html.customData setting to vscode plugin

--- a/packages/lit-analyzer/src/lib/analyze/data/get-built-in-html-collection.ts
+++ b/packages/lit-analyzer/src/lib/analyze/data/get-built-in-html-collection.ts
@@ -5,8 +5,9 @@ import type { HtmlAttr, HtmlDataCollection } from "../parse/parse-html-data/html
 import { parseVscodeHtmlData } from "../parse/parse-html-data/parse-vscode-html-data.js";
 import { lazy } from "../util/general-util.js";
 import { EXTRA_HTML5_EVENTS, hasTypeForAttrName, html5TagAttrType } from "./extra-html-data.js";
+import type { LitAnalyzerContext } from "../lit-analyzer-context.js";
 
-export function getBuiltInHtmlCollection(): HtmlDataCollection {
+export function getBuiltInHtmlCollection(context: LitAnalyzerContext): HtmlDataCollection {
 	const vscodeHtmlData = htmlDataJson as HTMLDataV1;
 
 	const version = vscodeHtmlData.version;
@@ -120,18 +121,30 @@ The value must be a comma-separated list of part mappings:
 		}
 	);
 
+	let result: HtmlDataCollection = { tags: [], global: {} };
+
 	// Parse vscode html data
-	const result = parseVscodeHtmlData(
-		{
+	try {
+		result = parseVscodeHtmlData(
+			{
+				version,
+				globalAttributes,
+				tags,
+				valueSets
+			},
+			context,
+			{
+				builtIn: true
+			}
+		);
+	} catch (e) {
+		context.logger.error("Error parsing configured html data", e, {
 			version,
 			globalAttributes,
 			tags,
 			valueSets
-		},
-		{
-			builtIn: true
-		}
-	);
+		});
+	}
 
 	// Add missing properties to the result, because they are not included in vscode html data
 	for (const tag of result.tags) {

--- a/packages/lit-analyzer/src/lib/analyze/data/get-user-config-html-collection.ts
+++ b/packages/lit-analyzer/src/lib/analyze/data/get-user-config-html-collection.ts
@@ -6,8 +6,9 @@ import type { HtmlAttr, HtmlDataCollection, HtmlEvent, HtmlTag } from "../parse/
 import { mergeHtmlAttrs, mergeHtmlEvents, mergeHtmlTags } from "../parse/parse-html-data/html-tag.js";
 import { parseVscodeHtmlData } from "../parse/parse-html-data/parse-vscode-html-data.js";
 import { lazy } from "../util/general-util.js";
+import type { LitAnalyzerContext } from "../lit-analyzer-context.js";
 
-export function getUserConfigHtmlCollection(config: LitAnalyzerConfig): HtmlDataCollection {
+export function getUserConfigHtmlCollection(config: LitAnalyzerConfig, context: LitAnalyzerContext): HtmlDataCollection {
 	const collection = (() => {
 		let collection: HtmlDataCollection = { tags: [], global: {} };
 		for (const customHtmlData of Array.isArray(config.customHtmlData) ? config.customHtmlData : [config.customHtmlData]) {
@@ -16,7 +17,7 @@ export function getUserConfigHtmlCollection(config: LitAnalyzerConfig): HtmlData
 					typeof customHtmlData === "string" && existsSync(customHtmlData)
 						? JSON.parse(readFileSync(customHtmlData, "utf8").toString())
 						: customHtmlData;
-				const parsedCollection = parseVscodeHtmlData(data);
+				const parsedCollection = parseVscodeHtmlData(data, context);
 				collection = {
 					tags: mergeHtmlTags([...collection.tags, ...parsedCollection.tags]),
 					global: {
@@ -25,7 +26,7 @@ export function getUserConfigHtmlCollection(config: LitAnalyzerConfig): HtmlData
 					}
 				};
 			} catch (e) {
-				//logger.error("Error parsing user configuration 'customHtmlData'", e, customHtmlData);
+				context.logger.error("Error parsing user configuration 'customHtmlData'", e, customHtmlData);
 			}
 		}
 		return collection;

--- a/packages/lit-analyzer/src/lib/analyze/default-lit-analyzer-context.ts
+++ b/packages/lit-analyzer/src/lib/analyze/default-lit-analyzer-context.ts
@@ -145,7 +145,7 @@ export class DefaultLitAnalyzerContext implements LitAnalyzerContext {
 		})();
 
 		// Add user configured HTML5 collection
-		const collection = getUserConfigHtmlCollection(config);
+		const collection = getUserConfigHtmlCollection(config, this);
 		this.htmlStore.absorbCollection(collection, HtmlDataSourceKind.USER);
 	}
 
@@ -164,7 +164,7 @@ export class DefaultLitAnalyzerContext implements LitAnalyzerContext {
 
 	constructor(private handler: LitPluginContextHandler) {
 		// Add all HTML5 tags and attributes
-		const builtInCollection = getBuiltInHtmlCollection();
+		const builtInCollection = getBuiltInHtmlCollection(this);
 		this.htmlStore.absorbCollection(builtInCollection, HtmlDataSourceKind.BUILT_IN);
 	}
 

--- a/packages/lit-analyzer/src/lib/analyze/parse/parse-html-data/parse-vscode-html-data.ts
+++ b/packages/lit-analyzer/src/lib/analyze/parse/parse-html-data/parse-vscode-html-data.ts
@@ -3,17 +3,22 @@ import type { HTMLDataV1, IAttributeData, ITagData, IValueData, IValueSet } from
 import type { MarkupContent } from "vscode-languageserver-types";
 import { lazy } from "../../util/general-util.js";
 import type { HtmlAttr, HtmlDataCollection, HtmlEvent, HtmlTag } from "./html-tag.js";
+import type { LitAnalyzerContext } from "../../lit-analyzer-context.js";
 
 export interface ParseVscodeHtmlDataConfig {
 	builtIn?: boolean;
 	typeMap?: Map<string, SimpleType>;
 }
 
-export function parseVscodeHtmlData(data: HTMLDataV1, config: ParseVscodeHtmlDataConfig = {}): HtmlDataCollection {
+export function parseVscodeHtmlData(data: HTMLDataV1, context: LitAnalyzerContext, config: ParseVscodeHtmlDataConfig = {}): HtmlDataCollection {
 	switch (data.version) {
 		case 1:
 		case 1.1:
 			return parseVscodeDataV1(data, config);
+		default:
+			context.logger.warn(`Unsupported Version ${data.version} found for VSCodeHtmlData. Supported versions are 1 and 1.1. Not including ${data}`);
+
+			return { tags: [], global: {} };
 	}
 }
 

--- a/packages/vscode-lit-plugin/src/extension.ts
+++ b/packages/vscode-lit-plugin/src/extension.ts
@@ -7,7 +7,7 @@ import * as vscode from "vscode";
 const tsLitPluginId = "@jackolope/ts-lit-plugin";
 const typeScriptExtensionId = "vscode.typescript-language-features";
 const configurationSection = "lit-analyzer-plugin";
-const configurationExperimentalHtmlSection = "html.experimental";
+const configurationHtmlSection = "html";
 const analyzeCommandId = "lit-analyzer-plugin.analyze";
 
 let defaultAnalyzeGlob = "src";
@@ -33,7 +33,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	// Subscribe to configuration change
 	vscode.workspace.onDidChangeConfiguration(
 		e => {
-			if (e.affectsConfiguration(configurationSection) || e.affectsConfiguration(configurationExperimentalHtmlSection)) {
+			if (e.affectsConfiguration(configurationSection) || e.affectsConfiguration(configurationHtmlSection)) {
 				synchronizeConfig(api);
 			}
 		},
@@ -140,9 +140,8 @@ function getConfig(): Partial<LitAnalyzerConfig> {
 		outConfig.customHtmlData = value;
 	});
 
-	// Experimental values from vscode
-	const experimental = vscode.workspace.getConfiguration(configurationExperimentalHtmlSection, null);
-	withConfigValue(experimental, "customData", value => {
+	const htmlSection = vscode.workspace.getConfiguration(configurationHtmlSection, null);
+	withConfigValue(htmlSection, "customData", value => {
 		// Merge value from vscode with "lit-analyzer-plugin.customHtmlData"
 		const filePaths = (Array.isArray(value) ? value : [value]).map(path => (typeof path === "string" ? toWorkspacePath(path) : path));
 		outConfig.customHtmlData = outConfig.customHtmlData == null ? filePaths : filePaths.concat(outConfig.customHtmlData as []);


### PR DESCRIPTION
The extension should now react to the VSCode `html.customData` setting:
https://github.com/microsoft/vscode-html-languageservice/blob/main/docs/customData.md

Most of the code to handle this already existed, it was just still looking at `html.experimental.customData` and hadn't been updated.

I've tested it using these two basic samples:
- https://github.com/microsoft/vscode-custom-data/blob/main/samples/webcomponents/src/web-components.html-data.json
- https://github.com/octref/vscode-mavo/blob/master/data/mavo.json

If you run into any issues or missing features from a more complex customData setup let me know! It's possible that the `customData` spec was updated since this original logic was added, but I couldn't find anything that indicated that.

Also improved error handling and logging around this feature a little.

Closes #181 