### PR TITLE
Revert no incompatible type undefined union

### DIFF
--- a/.changeset/real-bags-press.md
+++ b/.changeset/real-bags-press.md
@@ -1,0 +1,6 @@
+---
+"@jackolope/lit-analyzer": patch
+"lit-analyzer-plugin": patch
+---
+
+fix: Revert Make no-incompatible-type-binding rule ignore undefined when binding a property (with .) on union types

--- a/packages/lit-analyzer/src/lib/rules/util/type/is-assignable-in-property-binding.ts
+++ b/packages/lit-analyzer/src/lib/rules/util/type/is-assignable-in-property-binding.ts
@@ -18,10 +18,7 @@ export function isAssignableInPropertyBinding(
 		return securitySystemResult;
 	}
 
-	// Exclude `undefined` from union type checks
-	const filteredTypeB = typeB.kind === "UNION" ? { ...typeB, types: typeB.types.filter(type => type.kind !== "UNDEFINED") } : typeB;
-
-	if (!isAssignableToType({ typeA, typeB: filteredTypeB }, context)) {
+	if (!isAssignableToType({ typeA, typeB }, context)) {
 		context.report({
 			location: rangeFromHtmlNodeAttr(htmlAttr),
 			message: `Type '${typeToString(typeB)}' is not assignable to '${typeToString(typeA)}'`

--- a/packages/lit-analyzer/src/test/rules/no-incompatible-type-binding.ts
+++ b/packages/lit-analyzer/src/test/rules/no-incompatible-type-binding.ts
@@ -217,22 +217,6 @@ tsTest("Property binding: Boolean type expression is not assignable to boolean p
 	hasNoDiagnostics(t, diagnostics);
 });
 
-tsTest("Property binding: Type expression correctly removes 'undefined' from the type union 1", t => {
-	const { diagnostics } = getDiagnostics([
-		makeElement({ properties: ["foo = ''"] }),
-		'html`<my-element .foo="${"bar" as string | undefined}"></my-element>`'
-	]);
-	hasNoDiagnostics(t, diagnostics);
-});
-
-tsTest("Property binding: Type expression correctly removes 'undefined' from the type union 2", t => {
-	const { diagnostics } = getDiagnostics([
-		makeElement({ properties: ["foo: string | number = 0"] }),
-		'html`<my-element .foo="${5 as string | number | undefined}"></my-element>`'
-	]);
-	hasNoDiagnostics(t, diagnostics);
-});
-
 tsTest("Property binding: Type expression correctly reports a type union that is only partially met", t => {
 	const { diagnostics } = getDiagnostics([
 		makeElement({ properties: ["foo: number = 0"] }),


### PR DESCRIPTION
Reverting one of the changes from this PR:
https://github.com/JackRobards/lit-analyzer/pull/207

Considering reverting this change...

Two reasons for reverting this:

- Thinking more about it: how it was working before makes more sense - if undefined is possible, then the types should reflect that.
- If we are doing to do something like this, then I think we should look for a slightly more performant solution. The rule checks can run a lot of times to validate the templates, so we need to be careful when adding logic like this to a rule.

There is some performance logging in the tools, but it would be nice if there were some automated tests to track this. It's a little hard to tell what the performance impact of a change is as-is 🤔.