### PR TITLE
Add folding (code collapse) support to html, css, and svg template literals

### DIFF
--- a/.changeset/funny-doodles-worry.md
+++ b/.changeset/funny-doodles-worry.md
@@ -1,0 +1,7 @@
+---
+"lit-analyzer-plugin": minor
+---
+
+feat: Add ability to fold (collapse) code inside of html, css, and svg tempalte literals.
+
+This feature can be configured by a new "lit-analyzer-plugin.enableTaggedTemplateFolding" vscode setting. By default it is enabled, unless your editor.foldingStrategy setting is set to "indentation".

--- a/.changeset/zzz_dependabot-76e43ac-@jackolope-lit-analyzer.md
+++ b/.changeset/zzz_dependabot-76e43ac-@jackolope-lit-analyzer.md
@@ -1,0 +1,7 @@
+---
+"@jackolope/lit-analyzer": patch
+---
+
+Updated dependencies:
+Updated dependency `vscode-css-languageservice` to `6.3.4`.
+Updated devDependency `@types/node` to `^22.14.0`.

--- a/.changeset/zzz_dependabot-76e43ac-@jackolope-ts-lit-plugin.md
+++ b/.changeset/zzz_dependabot-76e43ac-@jackolope-ts-lit-plugin.md
@@ -1,0 +1,7 @@
+---
+"@jackolope/ts-lit-plugin": patch
+---
+
+Updated dependencies:
+Updated lit-analyzer to new version
+Updated devDependency `@types/node` to `^22.14.0`.

--- a/.changeset/zzz_dependabot-76e43ac-lit-analyzer-plugin.md
+++ b/.changeset/zzz_dependabot-76e43ac-lit-analyzer-plugin.md
@@ -1,0 +1,9 @@
+---
+"lit-analyzer-plugin": patch
+---
+
+Updated dependencies:
+Updated devDependency `@types/node` to `^22.14.0`.
+Updated dependency `@vscode/vsce` to `^3.3.2`.
+Updated dependency `@jackolope/lit-analyzer` to new version.
+Updated dependency `vscode-css-languageservice` to `6.3.4`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10790,6 +10790,8 @@
 				"esbuild": "^0.25.1",
 				"fast-glob": "^3.2.11",
 				"mocha": "^11.1.0",
+				"vscode-css-languageservice": "6.3.4",
+				"vscode-html-languageservice": "5.3.3",
 				"wireit": "^0.14.11"
 			},
 			"engines": {

--- a/packages/vscode-lit-plugin/README.md
+++ b/packages/vscode-lit-plugin/README.md
@@ -673,6 +673,7 @@ You can configure this plugin by going to `VS Code Settings` > `Extension` > `li
 | `dontShowSuggestions` | This option sets strict as  | `boolean` | false |
 | `htmlTemplateTags` | List of template tags to enable html support in. | `string[]` | ["html", "raw"] | |
 | `cssTemplateTags` | This option sets strict as | `string[]` | ["css"] |
+| `enableTaggedTemplateFolding` | Enables folding (code collapse) inside html, css, and svg tagged template literals. | `boolean` | true if `editor.foldingStrategy !== "indentation"`. false if it is |
 | `globalTags` |  List of html tag names that you expect to be present at all times. | `string[]` | |
 | `globalAttributes` | List of html attributes names that you expect to be present at all times. | `string[]` | |
 | `globalEvents` | List of event names that you expect to be present at all times | `string[]` | |

--- a/packages/vscode-lit-plugin/package.json
+++ b/packages/vscode-lit-plugin/package.json
@@ -177,6 +177,8 @@
 		"fast-glob": "^3.2.11",
 		"@jackolope/lit-analyzer": "^3.1.1",
 		"mocha": "^11.1.0",
+		"vscode-css-languageservice": "6.3.4",
+		"vscode-html-languageservice": "5.3.3",
 		"wireit": "^0.14.11"
 	},
 	"activationEvents": [

--- a/packages/vscode-lit-plugin/package.json
+++ b/packages/vscode-lit-plugin/package.json
@@ -267,6 +267,11 @@
 							"css"
 						]
 					},
+					"lit-analyzer-plugin.enableTaggedTemplateFolding": {
+						"type": "boolean",
+						"description": "Enables folding (code collapse) inside html, css, and svg tagged template literals. Defaults to false if editor.foldingStrategy is 'indentation'.",
+						"default": true
+					},
 					"lit-analyzer-plugin.dontShowSuggestions": {
 						"type": "boolean",
 						"description": "Don't append messages suggesting how to fix diagnostics.",

--- a/packages/vscode-lit-plugin/schemas/tsconfig.schema.json
+++ b/packages/vscode-lit-plugin/schemas/tsconfig.schema.json
@@ -63,6 +63,11 @@
 									},
 									"default": ["css"]
 								},
+								"enableTaggedTemplateFolding": {
+									"type": "boolean",
+									"description": "Enables folding (code collapse) inside html, css, and svg tagged template literals. Defaults to false if editor.foldingStrategy is 'indentation'.",
+									"default": true
+								},
 								"dontShowSuggestions": {
 									"type": "boolean",
 									"description": "Don't append messages suggesting how to fix diagnostics.",

--- a/packages/vscode-lit-plugin/src/color-provider.ts
+++ b/packages/vscode-lit-plugin/src/color-provider.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { getRegexMatches } from "./utils.js";
 
 /**
  * Regex to match colors in a string
@@ -79,26 +80,6 @@ function hexToVscodeColor(hex: string): vscode.Color | undefined {
 	const rgba = hexToRGBA(hex);
 	if (rgba == null) return undefined;
 	return new vscode.Color(rgba.red / 255, rgba.green / 255, rgba.blue / 255, rgba.alpha / 255);
-}
-
-/**
- * Matches a regex on a text and returns all positions where a match was found
- * @param regex
- * @param text
- * @param callback
- */
-function getRegexMatches(regex: RegExp, text: string): { start: number; text: string }[] {
-	// Find all hex colors in the document
-	let match: RegExpExecArray | null = null;
-
-	const matches: { start: number; text: string }[] = [];
-
-	while ((match = regex.exec(text)) != null) {
-		const start = match.index;
-		matches.push({ start, text: match[0] });
-	}
-
-	return matches;
 }
 
 /**

--- a/packages/vscode-lit-plugin/src/extension.ts
+++ b/packages/vscode-lit-plugin/src/extension.ts
@@ -2,6 +2,7 @@ import type { LitAnalyzerConfig } from "@jackolope/lit-analyzer";
 import { ALL_RULE_IDS } from "@jackolope/lit-analyzer";
 import { join } from "path";
 import { ColorProvider } from "./color-provider.js";
+import { FoldingProvider } from "./folding-provider.js";
 import * as vscode from "vscode";
 
 const tsLitPluginId = "@jackolope/ts-lit-plugin";
@@ -13,6 +14,7 @@ const analyzeCommandId = "lit-analyzer-plugin.analyze";
 let defaultAnalyzeGlob = "src";
 
 const colorProvider = new ColorProvider();
+const foldingProvider = new FoldingProvider();
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
 	const extension = vscode.extensions.getExtension(typeScriptExtensionId);
@@ -45,14 +47,23 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	context.subscriptions.push(vscode.commands.registerCommand(analyzeCommandId, handleAnalyzeCommand));
 
 	// Register a color provider
-	const registration = vscode.languages.registerColorProvider(
+	const colorRegistration = vscode.languages.registerColorProvider(
 		[
 			{ scheme: "file", language: "typescript" },
 			{ scheme: "file", language: "javascript" }
 		],
 		colorProvider
 	);
-	context.subscriptions.push(registration);
+
+	const foldingRegistration = vscode.languages.registerFoldingRangeProvider(
+		[
+			{ scheme: "file", language: "typescript" },
+			{ scheme: "file", language: "javascript" }
+		],
+		foldingProvider
+	);
+	context.subscriptions.push(colorRegistration);
+	context.subscriptions.push(foldingRegistration);
 
 	synchronizeConfig(api);
 }

--- a/packages/vscode-lit-plugin/src/folding-provider.ts
+++ b/packages/vscode-lit-plugin/src/folding-provider.ts
@@ -1,0 +1,68 @@
+import * as vscode from "vscode";
+import { getLanguageService as getHtmlLanguageService, TextDocument as HTMLTextDocument, FoldingRangeKind } from "vscode-html-languageservice";
+import { getCSSLanguageService, TextDocument as CSSTextDocument } from "vscode-css-languageservice";
+import { getRegexMatches } from "./utils.js";
+
+// Also support `svg` tagged template literals using the vscode-html-languageservice
+const HTML_SECTION_REGEX = /(html|svg)`([\s\S]*?)`/gi;
+const CSS_SECTION_REGEX = /(css)`([\s\S]*?)`/gi;
+
+const htmlLanguageService = getHtmlLanguageService();
+const cssLanguageService = getCSSLanguageService();
+
+// Html and CSS language services share the same enums
+const htmlOrCSSToVSCodeFoldingRangeKind = {
+	[FoldingRangeKind.Comment]: vscode.FoldingRangeKind.Comment,
+	[FoldingRangeKind.Imports]: vscode.FoldingRangeKind.Imports,
+	[FoldingRangeKind.Region]: vscode.FoldingRangeKind.Region
+};
+
+/**
+ * Exports a color provider that makes it possible to highlight colors within "css" and "html" tagged templates.
+ */
+export class FoldingProvider implements vscode.FoldingRangeProvider {
+	provideFoldingRanges(document: vscode.TextDocument, context: vscode.FoldingContext, token: vscode.CancellationToken): vscode.FoldingRange[] {
+		const documentText = document.getText();
+		const foldingRanges: vscode.FoldingRange[] = [];
+
+		// Find all html template literals to calculate folding regions for
+		const htmlTemplateLiterals = getRegexMatches(HTML_SECTION_REGEX, documentText);
+
+		for (const { text: taggedTemplateText, start: taggedTemplateOffset } of htmlTemplateLiterals) {
+			const templateLineStart = document.positionAt(taggedTemplateOffset).line;
+			const htmlContent = HTMLTextDocument.create(document.uri.toString(), document.languageId, document.version, taggedTemplateText);
+
+			const htmlFoldingRanges = htmlLanguageService.getFoldingRanges(htmlContent, context);
+			htmlFoldingRanges.forEach(({ startLine, endLine, kind }) => {
+				const vscodeKind =
+					kind && kind in htmlOrCSSToVSCodeFoldingRangeKind
+						? htmlOrCSSToVSCodeFoldingRangeKind[kind as keyof typeof htmlOrCSSToVSCodeFoldingRangeKind]
+						: undefined;
+
+				const foldingRange = new vscode.FoldingRange(startLine + templateLineStart, endLine + templateLineStart, vscodeKind);
+				foldingRanges.push(foldingRange);
+			});
+		}
+
+		// Find all css template literals to calculate folding regions for
+		const cssTemplateLiterals = getRegexMatches(CSS_SECTION_REGEX, documentText);
+
+		for (const { text: taggedTemplateText, start: taggedTemplateOffset } of cssTemplateLiterals) {
+			const templateLineStart = document.positionAt(taggedTemplateOffset).line;
+			const htmlContent = CSSTextDocument.create(document.uri.toString(), document.languageId, document.version, taggedTemplateText);
+
+			const cssFoldingRanges = cssLanguageService.getFoldingRanges(htmlContent, context);
+			cssFoldingRanges.forEach(({ startLine, endLine, kind }) => {
+				const vscodeKind =
+					kind && kind in htmlOrCSSToVSCodeFoldingRangeKind
+						? htmlOrCSSToVSCodeFoldingRangeKind[kind as keyof typeof htmlOrCSSToVSCodeFoldingRangeKind]
+						: undefined;
+
+				const foldingRange = new vscode.FoldingRange(startLine + templateLineStart, endLine + templateLineStart, vscodeKind);
+				foldingRanges.push(foldingRange);
+			});
+		}
+
+		return foldingRanges;
+	}
+}

--- a/packages/vscode-lit-plugin/src/utils.ts
+++ b/packages/vscode-lit-plugin/src/utils.ts
@@ -1,0 +1,18 @@
+/**
+ * Matches a regex on a text and returns all positions where a match was found
+ * @param regex
+ * @param text
+ * @param callback
+ */
+export function getRegexMatches(regex: RegExp, text: string): { start: number; text: string }[] {
+	let match: RegExpExecArray | null = null;
+
+	const matches: { start: number; text: string }[] = [];
+
+	while ((match = regex.exec(text)) != null) {
+		const start = match.index;
+		matches.push({ start, text: match[0] });
+	}
+
+	return matches;
+}

--- a/scripts/create-dependency-changesets.mjs
+++ b/scripts/create-dependency-changesets.mjs
@@ -23,7 +23,7 @@ async function getPackagesNames(files) {
 }
 
 async function createChangeset(fileName, packageBumps, packages) {
-	let message = "";
+	let message = "Updated dependencies:\n";
 	for (const [pkg, bump] of packageBumps) {
 		message = message + `Updated dependency \`${pkg}\` to \`${bump}\`.\n`;
 	}
@@ -43,7 +43,11 @@ async function getBumps(files) {
 				continue;
 			}
 			const match = change.match(/"(.*?)"/g);
-			bumps.set(match[0].replace(/"/g, ""), match[1].replace(/"/g, ""));
+
+			// Not a version change
+			if (!match || match.length !== 2) continue;
+
+			bumps.set(match[0]?.replace(/"/g, ""), match[1]?.replace(/"/g, ""));
 		}
 	}
 	return bumps;
@@ -64,7 +68,8 @@ if (!packageNames.length) {
 const { stdout: shortHash } = await getExecOutput("git rev-parse --short HEAD");
 
 for (const [i, file] of files.entries()) {
-	const fileName = `.changeset/dependabot-${shortHash.trim()}-${packageNames[i].replace("/", "-")}.md`;
+	// zzz so that the dependency changes will always come last
+	const fileName = `.changeset/zzz_dependabot-${shortHash.trim()}-${packageNames[i].replace("/", "-")}.md`;
 
 	const packageBumps = await getBumps([file]);
 	console.log(`Package updates for ${file}:\n`, packageBumps);


### PR DESCRIPTION
This leverages the `vscode-html-languageservice` and `vscode-css-languageservice` packages to provide a [VSCode FoldingRangerProvider](https://code.visualstudio.com/api/references/vscode-api#FoldingRangeProvider) for these tagged template literals that Lit uses. Since it is re-using the folding logic from these extensions directly, it keeps the logic here pretty simple and works well enough from my testing to be very useful!

There is a new `lit-analyzer-plugin.enableTaggedTemplateFolding` vscode setting to enable/disable this feature. By default it is enabled, unless you have the `editor.foldingStrategy` set to "indendation" in vscode. 

I have noticed a little weirdness when multiple `html` template literals are nested inside each other. The change in this PR doesn't break anything in this case, but it won't correctly add the folding sections to all of the outer tags. Since this is a bit more of an advanced use case, I'm thinking that I will proceed with this PR, then I can circle back on improving this case based on interest/need.

If you run into any issues with this feature let me know by opening up an issue!

I have also included the changeset files for the dependency updates in this PR, since I am planning to do a quick release for this feature + the CSS language service version bump.

_Side note_:
There was some previous support for this feature that is commented out that I will probably delete later. It stopped working and was disabled when the `getOutliningSpans`  feature was removed from TypeScript: https://github.com/microsoft/TypeScript/issues/23382