### PR TITLE
🐛 fix `no-property-visibility-mismatch` work with `#property`.

### DIFF
--- a/.changeset/easy-roses-hunt.md
+++ b/.changeset/easy-roses-hunt.md
@@ -1,0 +1,5 @@
+---
+"@jackolope/lit-analyzer": patch
+---
+
+add `#property` support for rule: `no-property-visibility-mismatch`

--- a/packages/lit-analyzer/src/lib/rules/no-property-visibility-mismatch.ts
+++ b/packages/lit-analyzer/src/lib/rules/no-property-visibility-mismatch.ts
@@ -48,7 +48,7 @@ const rule: RuleModule = {
 		const hasPropertyDecorator = decoratorName === "property";
 
 		// Handle cases where @state decorator is used, but the property is public
-		if (hasInternalDecorator && (member.visibility === "public" || member.visibility == null)) {
+		if (hasInternalDecorator && (member.visibility === "public" || member.visibility == null) && member.propName[0] !== "#") {
 			const inJsFile = context.file.fileName.endsWith(".js");
 
 			context.report({
@@ -115,7 +115,7 @@ const rule: RuleModule = {
 		}
 
 		// Handle cases where @property decorator is used, but the property is not public
-		else if (hasPropertyDecorator && member.visibility !== "public") {
+		else if (hasPropertyDecorator && (member.visibility !== "public" || member.propName[0] === "#")) {
 			// If the Lit `state` option is set on the decorator, then that is also considered valid
 			if (member.meta?.state) {
 				return;

--- a/packages/lit-analyzer/src/test/rules/no-property-visibility-mismatch.ts
+++ b/packages/lit-analyzer/src/test/rules/no-property-visibility-mismatch.ts
@@ -71,3 +71,31 @@ tsTest("Don't report private @property properties with `state` true", t => {
 	);
 	hasNoDiagnostics(t, diagnostics);
 });
+
+tsTest("Don't report @state properties with '#' prefix", t => {
+	const { diagnostics } = getDiagnostics(
+		makeTestElement({
+			properties: [{ name: "#foo", visibility: "", internal: true }]
+		}),
+		{
+			rules: {
+				"no-property-visibility-mismatch": true
+			}
+		}
+	);
+	hasNoDiagnostics(t, diagnostics);
+});
+
+tsTest("Report @property properties with '#' prefix", t => {
+	const { diagnostics } = getDiagnostics(
+		makeTestElement({
+			properties: [{ name: "#foo", visibility: "", internal: false }]
+		}),
+		{
+			rules: {
+				"no-property-visibility-mismatch": true
+			}
+		}
+	);
+	hasDiagnostic(t, diagnostics, "no-property-visibility-mismatch");
+});


### PR DESCRIPTION
`#property` is private property too.