### PR TITLE
🐛 fix `no-noncallable-event-binding` work with 'INTERSECTION' kind

### DIFF
--- a/.changeset/shaky-ghosts-watch.md
+++ b/.changeset/shaky-ghosts-watch.md
@@ -1,0 +1,5 @@
+---
+"@jackolope/lit-analyzer": patch
+---
+
+add INTERSECTION-kind support for `no-noncallable-event-binding` rule check

--- a/packages/lit-analyzer/src/lib/rules/no-noncallable-event-binding.ts
+++ b/packages/lit-analyzer/src/lib/rules/no-noncallable-event-binding.ts
@@ -50,6 +50,10 @@ function isTypeBindableToEventListener(type: SimpleType): boolean {
 
 	return validateType(type, simpleType => {
 		switch (simpleType.kind) {
+			// Intersection types can be used if one of the types is callable
+			case "INTERSECTION": {
+				return simpleType.types.some(t => isTypeBindableToEventListener(t));
+			}
 			// Object types with attributes for the setup function of the event listener can be used
 			case "OBJECT":
 			case "INTERFACE": {

--- a/packages/lit-analyzer/src/test/rules/no-noncallable-event-binding.ts
+++ b/packages/lit-analyzer/src/test/rules/no-noncallable-event-binding.ts
@@ -22,6 +22,11 @@ tsTest("Event binding: Function is bindable", t => {
 	hasNoDiagnostics(t, diagnostics);
 });
 
+tsTest("Event binding: Function with property is bindable", t => {
+	const { diagnostics } = getDiagnostics('const foo = Object.assign(() => {}, {passive: true}); html`<input @change="${foo}" />`');
+	hasNoDiagnostics(t, diagnostics);
+});
+
 tsTest("Event binding: Called function is not bindable", t => {
 	const { diagnostics } = getDiagnostics('function foo() {}; html`<input @change="${foo()}" />`');
 	hasDiagnostic(t, diagnostics, "no-noncallable-event-binding");


### PR DESCRIPTION
The essence of `@eventOptions()` is to do [Object.assign(method, options)](https://github.com/lit/lit/blob/main/packages/reactive-element/src/decorators/event-options.ts)

In some cases, instead of using `@eventOptions()`, event-options can be configured directly through `Object.assign`.
Therefore, it is necessary to add support for the INTERSECTION type check.