### PR TITLE
fix(web-component-analyzer): Add support for identifying the visibility of JavaScript private (#) properties

### DIFF
--- a/.changeset/curvy-badgers-count.md
+++ b/.changeset/curvy-badgers-count.md
@@ -1,0 +1,7 @@
+---
+"@jackolope/web-component-analyzer": patch
+"@jackolope/ts-lit-plugin": patch
+"lit-analyzer-plugin": patch
+---
+
+Add private `#property` support for web-component-analyzer

--- a/packages/web-component-analyzer/src/analyze/flavors/custom-element/discover-members.ts
+++ b/packages/web-component-analyzer/src/analyze/flavors/custom-element/discover-members.ts
@@ -62,7 +62,7 @@ export function discoverMembers(node: Node, context: AnalyzerDeclarationVisitCon
 			return node;
 		})();
 
-		if (ts.isIdentifier(name) || ts.isStringLiteralLike(name)) {
+		if (ts.isIdentifier(name) || ts.isStringLiteralLike(name) || ts.isPrivateIdentifier(name)) {
 			// Always ignore the "prototype" property
 			if (name.text === "prototype") {
 				return undefined;

--- a/packages/web-component-analyzer/src/analyze/util/ast-util.ts
+++ b/packages/web-component-analyzer/src/analyze/util/ast-util.ts
@@ -64,7 +64,13 @@ export function getMemberVisibilityFromNode(
 	node: PropertyDeclaration | PropertySignature | SetAccessorDeclaration | Node,
 	ts: typeof tsModule
 ): VisibilityKind | undefined {
-	if (hasModifier(node, ts.SyntaxKind.PrivateKeyword, ts) || ("name" in node && ts.isIdentifier(node.name) && isNamePrivate(node.name.text))) {
+	// Has a private '#' Identifier
+	const isTrulyPrivate = "name" in node && ts.isPrivateIdentifier(node.name);
+
+	// Name starts with an underscore `_`
+	const hasPrivateName = "name" in node && ts.isIdentifier(node.name) && isNamePrivate(node.name.text);
+
+	if (hasModifier(node, ts.SyntaxKind.PrivateKeyword, ts) || isTrulyPrivate || hasPrivateName) {
 		return "private";
 	} else if (hasModifier(node, ts.SyntaxKind.ProtectedKeyword, ts)) {
 		return "protected";

--- a/packages/web-component-analyzer/test/flavors/custom-element/visibility-test.ts
+++ b/packages/web-component-analyzer/test/flavors/custom-element/visibility-test.ts
@@ -70,3 +70,37 @@ tsTest("Handle visibility for private '_' prefixed names", t => {
 		checker
 	);
 });
+
+tsTest("Handle visibility for private '#' prefixed names", t => {
+	const {
+		results: [result],
+		checker
+	} = analyzeTextWithCurrentTsModule(`
+	/**
+	 * @element
+	 */
+	class MyElement extends HTMLElement {
+		#myProp = 123;
+		#myMethod () {
+		}
+	}
+`);
+
+	const { members = [], methods: [method] = [] } = result.componentDefinitions[0]?.declaration || {};
+
+	t.is(method.name, "#myMethod");
+	t.is(method.visibility, "private");
+
+	assertHasMembers(
+		members,
+		[
+			{
+				kind: "property",
+				propName: "#myProp",
+				visibility: "private"
+			}
+		],
+		t,
+		checker
+	);
+});


### PR DESCRIPTION
The same idea as [this change](https://github.com/JackRobards/lit-analyzer/pull/258/files), but handling it in the `web-component-analyzer` package.

There was related logic in the `ast-util.ts` file for the handling the visibility in the `getMemberVisibilityFromNode` method. It wasn't working correctly for `#` private properties, and fixing that should fix the problem with the `no-property-visibility-mismatch` rule.

This should also make these properties get detected correctly anywhere else the `visibility` matters in the rules. As far as I know it only effects this one rule currently though