### PR TITLE
chore: Downgrade @types/vscode version to match the engines.vscode version specified in the extension package.json

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -18,7 +18,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
         # Automatically merge semver-patch and semver-minor PRs for certain devDependencies
-        if: "${{ (contains(steps.metadata.outputs.dependency-names, 'eslint') || contains(steps.metadata.outputs.dependency-names, '@types/')) && 
+        if: "${{ (contains(steps.metadata.outputs.dependency-names, 'eslint') || contains(steps.metadata.outputs.dependency-names, '@types/node')) &&
           (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch') }}"
         run: gh pr review --approve "$PR_URL" && gh pr merge --auto --merge "$PR_URL"
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2383,13 +2383,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@types/vscode": {
-			"version": "1.99.1",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.99.1.tgz",
-			"integrity": "sha512-cQlqxHZ040ta6ovZXnXRxs3fJiTmlurkIWOfZVcLSZPcm9J4ikFpXuB7gihofGn5ng+kDVma5EmJIclfk0trPQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "8.32.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.0.tgz",
@@ -11523,7 +11516,7 @@
 				"@jackolope/lit-analyzer": "^3.1.3",
 				"@types/mocha": "^10.0.10",
 				"@types/node": "^22.15.8",
-				"@types/vscode": "^1.99.1",
+				"@types/vscode": "1.63.0",
 				"@vscode/vsce": "^3.3.2",
 				"esbuild": "^0.25.3",
 				"fast-glob": "^3.2.11",
@@ -11536,6 +11529,13 @@
 				"node": ">=18",
 				"vscode": "^1.63.0"
 			}
+		},
+		"packages/vscode-lit-plugin/node_modules/@types/vscode": {
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.63.0.tgz",
+			"integrity": "sha512-iePu1axOi5WSThV6l2TYcciBIpAlMarjBC8H0y8L8ocsZLxh7MttzwFU3pjoItF5fRVGxHS0Hsvje9jO3yJsfw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"packages/web-component-analyzer": {
 			"name": "@jackolope/web-component-analyzer",

--- a/packages/vscode-lit-plugin/package.json
+++ b/packages/vscode-lit-plugin/package.json
@@ -171,7 +171,7 @@
 	"devDependencies": {
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^22.15.8",
-		"@types/vscode": "^1.99.1",
+		"@types/vscode": "1.63.0",
 		"@vscode/vsce": "^3.3.2",
 		"esbuild": "^0.25.3",
 		"fast-glob": "^3.2.11",


### PR DESCRIPTION
The auto-merge check bumped the `@types/vscode` version to one higher than the specified `engines.vscode` version, which has started causing the build to fail.

The extension hasn't started to use the newer vscode features yet, so we don't need to update the `engines.vscode` version.