### PR TITLE
feat(syntaxes): Lit html syntax updates

### DIFF
--- a/.changeset/social-months-divide.md
+++ b/.changeset/social-months-divide.md
@@ -1,0 +1,5 @@
+---
+"lit-analyzer-plugin": minor
+---
+
+Update lit-html syntaxes for nicer styling inside tagged templates

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,4 +42,8 @@ You can use this script if you want to generate an installable package of vscode
 
 ### Syntaxes
 
-All syntaxes come from [vscode-lit-html](https://github.com/mjbvz/vscode-lit-html) and [vscode-styled-components](https://github.com/styled-components/vscode-styled-components). Because these repositories are not published as npm-packages, they are instead installed from Github URLs. Therefore, as of now, changes to syntaxes must be upstreamed to one of these repositories.
+All syntaxes originally came from [vscode-lit-html](https://github.com/mjbvz/vscode-lit-html) and [vscode-styled-components](https://github.com/styled-components/vscode-styled-components). They are copied here and bundled as part of the VSCode extension.
+
+The `text.html.lit-template` syntax is based on the `text.html.ember-handlebars` one for [vsc-ember-syntax](https://github.com/lifeart/vsc-ember-syntax/tree/master/syntaxes), but modified and simplified to fit Lit.
+
+Big thanks and credit to the original authors for these syntaxes!

--- a/packages/vscode-lit-plugin/package.json
+++ b/packages/vscode-lit-plugin/package.json
@@ -776,6 +776,11 @@
 		],
 		"grammars": [
 			{
+				"label": "HTML Template (Lit)",
+				"scopeName": "text.html.lit-template",
+				"path": "./syntaxes/vscode-lit-html/text.html.lit-template.json"
+			},
+			{
 				"injectTo": [
 					"source.js",
 					"source.js.jsx",

--- a/packages/vscode-lit-plugin/syntaxes/vscode-lit-html/lit-html.json
+++ b/packages/vscode-lit-plugin/syntaxes/vscode-lit-html/lit-html.json
@@ -1,6 +1,6 @@
 {
-	"fileTypes": ["js", "ts"],
-	"injectionSelector": "L:source.js -comment -(string -meta.embedded), L:source.ts -comment -(string -meta.embedded)",
+	"fileTypes": [],
+	"injectionSelector": "L:source.js -comment -(string -meta.embedded), L:source.jsx -comment -(string -meta.embedded),  L:source.js.jsx -comment -(string -meta.embedded), L:source.ts -comment -(string -meta.embedded), L:source.tsx -comment -(string -meta.embedded)",
 	"injections": {
 		"L:source": {
 			"patterns": [
@@ -37,12 +37,12 @@
 					"include": "source.ts#template-substitution-element"
 				},
 				{
-					"include": "text.html.ember-handlebars"
+					"include": "text.html.lit-template"
 				}
 			]
 		},
 		{
-			"begin": "((createTemplate|hbs|html))(\\()",
+			"begin": "((html))(\\()",
 			"contentName": "meta.embedded.block.html",
 			"beginCaptures": {
 				"1": {
@@ -83,66 +83,12 @@
 					},
 					"patterns": [
 						{
-							"include": "text.html.ember-handlebars"
+							"include": "text.html.lit-template"
 						}
 					]
-				}
-			]
-		},
-		{
-			"begin": "((precompileTemplate)\\s*)(\\()",
-			"beginCaptures": {
-				"1": {
-					"name": "entity.name.function.ts"
-				},
-				"2": {
-					"name": "meta.function-call.ts"
-				},
-				"3": {
-					"name": "meta.brace.round.ts"
-				}
-			},
-			"end": "(\\))",
-			"endCaptures": {
-				"1": {
-					"name": "meta.brace.round.ts"
-				}
-			},
-			"patterns": [
-				{
-					"begin": "((`|'|\"))",
-					"contentName": "meta.embedded.block.html",
-					"beginCaptures": {
-						"1": {
-							"name": "string.template.ts"
-						},
-						"2": {
-							"name": "punctuation.definition.string.template.begin.ts"
-						}
-					},
-					"end": "((`|'|\"))",
-					"endCaptures": {
-						"1": {
-							"name": "string.template.ts"
-						},
-						"2": {
-							"name": "punctuation.definition.string.template.end.ts"
-						}
-					},
-					"patterns": [
-						{
-							"include": "text.html.ember-handlebars"
-						}
-					]
-				},
-				{
-					"include": "source.ts#object-literal"
-				},
-				{
-					"include": "source.ts"
 				}
 			]
 		}
 	],
-	"scopeName": "inline.hbs"
+	"scopeName": "inline.lit-html"
 }

--- a/packages/vscode-lit-plugin/syntaxes/vscode-lit-html/lit-html.json
+++ b/packages/vscode-lit-plugin/syntaxes/vscode-lit-html/lit-html.json
@@ -1,6 +1,6 @@
 {
-	"fileTypes": [],
-	"injectionSelector": "L:source.js -comment -(string -meta.embedded), L:source.jsx -comment -(string -meta.embedded),  L:source.js.jsx -comment -(string -meta.embedded), L:source.ts -comment -(string -meta.embedded), L:source.tsx -comment -(string -meta.embedded)",
+	"fileTypes": ["js", "ts"],
+	"injectionSelector": "L:source.js -comment -(string -meta.embedded), L:source.ts -comment -(string -meta.embedded)",
 	"injections": {
 		"L:source": {
 			"patterns": [
@@ -13,7 +13,6 @@
 	},
 	"patterns": [
 		{
-			"name": "string.js.taggedTemplate",
 			"contentName": "meta.embedded.block.html",
 			"begin": "(?x)(\\b(?:\\w+\\.)*(?:html|raw)\\s*)(`)",
 			"beginCaptures": {
@@ -38,10 +37,112 @@
 					"include": "source.ts#template-substitution-element"
 				},
 				{
-					"include": "text.html.basic"
+					"include": "text.html.ember-handlebars"
+				}
+			]
+		},
+		{
+			"begin": "((createTemplate|hbs|html))(\\()",
+			"contentName": "meta.embedded.block.html",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.name.function.ts"
+				},
+				"2": {
+					"name": "meta.function-call.ts"
+				},
+				"3": {
+					"name": "meta.brace.round.ts"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "meta.brace.round.ts"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "((`|'|\"))",
+					"beginCaptures": {
+						"1": {
+							"name": "string.template.ts"
+						},
+						"2": {
+							"name": "punctuation.definition.string.template.begin.ts"
+						}
+					},
+					"end": "((`|'|\"))",
+					"endCaptures": {
+						"1": {
+							"name": "string.template.ts"
+						},
+						"2": {
+							"name": "punctuation.definition.string.template.end.ts"
+						}
+					},
+					"patterns": [
+						{
+							"include": "text.html.ember-handlebars"
+						}
+					]
+				}
+			]
+		},
+		{
+			"begin": "((precompileTemplate)\\s*)(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.name.function.ts"
+				},
+				"2": {
+					"name": "meta.function-call.ts"
+				},
+				"3": {
+					"name": "meta.brace.round.ts"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "meta.brace.round.ts"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "((`|'|\"))",
+					"contentName": "meta.embedded.block.html",
+					"beginCaptures": {
+						"1": {
+							"name": "string.template.ts"
+						},
+						"2": {
+							"name": "punctuation.definition.string.template.begin.ts"
+						}
+					},
+					"end": "((`|'|\"))",
+					"endCaptures": {
+						"1": {
+							"name": "string.template.ts"
+						},
+						"2": {
+							"name": "punctuation.definition.string.template.end.ts"
+						}
+					},
+					"patterns": [
+						{
+							"include": "text.html.ember-handlebars"
+						}
+					]
+				},
+				{
+					"include": "source.ts#object-literal"
+				},
+				{
+					"include": "source.ts"
 				}
 			]
 		}
 	],
-	"scopeName": "inline.lit-html"
+	"scopeName": "inline.hbs"
 }

--- a/packages/vscode-lit-plugin/syntaxes/vscode-lit-html/text.html.lit-template.json
+++ b/packages/vscode-lit-plugin/syntaxes/vscode-lit-html/text.html.lit-template.json
@@ -1,8 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-	"name": "Glimmer",
-	"scopeName": "text.html.ember-handlebars",
-	"fileTypes": ["hbs"],
+	"name": "Lit Template",
+	"scopeName": "text.html.lit-template",
 	"patterns": [
 		{
 			"include": "#style"
@@ -11,168 +10,52 @@
 			"include": "#script"
 		},
 		{
-			"include": "#glimmer-else-block"
-		},
-		{
-			"include": "#glimmer-bools"
-		},
-		{
-			"include": "#glimmer-special-block"
-		},
-		{
-			"include": "#glimmer-unescaped-expression"
-		},
-		{
-			"include": "#glimmer-comment-block"
-		},
-		{
-			"include": "#glimmer-comment-inline"
-		},
-		{
-			"include": "#glimmer-expression-property"
-		},
-		{
-			"include": "#glimmer-control-expression"
-		},
-		{
-			"include": "#glimmer-expression"
-		},
-		{
-			"include": "#glimmer-block"
-		},
-		{
 			"include": "#html-tag"
 		},
 		{
-			"include": "#component-tag"
-		},
-		{
 			"include": "#html-comment"
-		},
-		{
-			"include": "#entities"
 		}
 	],
 	"repository": {
-		"glimmer-component-path": {
-			"match": "(::|_|\\$|\\.)",
-			"captures": {
-				"1": {
-					"name": "punctuation.definition.tag"
-				}
-			}
-		},
-		"string-double-quoted-handlebars": {
-			"name": "string.quoted.double.ember-handlebars",
-			"begin": "\"",
-			"beginCaptures": {
-				"0": {
-					"name": "punctuation.definition.string.begin.ember-handlebars"
-				}
-			},
-			"end": "\"",
-			"endCaptures": {
-				"0": {
-					"name": "punctuation.definition.string.end.ember-handlebars"
-				}
-			},
-			"patterns": [
-				{
-					"name": "constant.character.escape.ember-handlebars",
-					"match": "\\\\\""
-				}
-			]
-		},
-		"string-single-quoted-handlebars": {
-			"name": "string.quoted.single.ember-handlebars",
-			"begin": "'",
-			"beginCaptures": {
-				"0": {
-					"name": "punctuation.definition.string.begin.ember-handlebars"
-				}
-			},
-			"end": "'",
-			"endCaptures": {
-				"0": {
-					"name": "punctuation.definition.string.end.ember-handlebars"
-				}
-			},
-			"patterns": [
-				{
-					"name": "constant.character.escape.ember-handlebars",
-					"match": "\\\\'"
-				}
-			]
-		},
 		"string-double-quoted-html": {
-			"name": "string.quoted.double.html.ember-handlebars",
+			"name": "string.quoted.double.html.lit-template",
 			"begin": "\"",
 			"beginCaptures": {
 				"0": {
-					"name": "punctuation.definition.string.begin.ember-handlebars"
+					"name": "punctuation.definition.string.begin.lit-template"
 				}
 			},
 			"end": "\"",
 			"endCaptures": {
 				"0": {
-					"name": "punctuation.definition.string.end.ember-handlebars"
+					"name": "punctuation.definition.string.end.lit-template"
 				}
 			},
 			"patterns": [
 				{
-					"name": "constant.character.escape.ember-handlebars",
+					"name": "constant.character.escape.lit-template",
 					"match": "\\\\\""
-				},
-				{
-					"include": "#glimmer-bools"
-				},
-				{
-					"include": "#glimmer-expression-property"
-				},
-				{
-					"include": "#glimmer-control-expression"
-				},
-				{
-					"include": "#glimmer-expression"
-				},
-				{
-					"include": "#glimmer-block"
 				}
 			]
 		},
 		"string-single-quoted-html": {
-			"name": "string.quoted.single.html.ember-handlebars",
+			"name": "string.quoted.single.html.lit-template",
 			"begin": "'",
 			"beginCaptures": {
 				"0": {
-					"name": "punctuation.definition.string.begin.ember-handlebars"
+					"name": "punctuation.definition.string.begin.lit-template"
 				}
 			},
 			"end": "'",
 			"endCaptures": {
 				"0": {
-					"name": "punctuation.definition.string.end.ember-handlebars"
+					"name": "punctuation.definition.string.end.lit-template"
 				}
 			},
 			"patterns": [
 				{
-					"name": "constant.character.escape.ember-handlebars",
+					"name": "constant.character.escape.lit-template",
 					"match": "\\\\'"
-				},
-				{
-					"include": "#glimmer-bools"
-				},
-				{
-					"include": "#glimmer-expression-property"
-				},
-				{
-					"include": "#glimmer-control-expression"
-				},
-				{
-					"include": "#glimmer-expression"
-				},
-				{
-					"include": "#glimmer-block"
 				}
 			]
 		},
@@ -204,434 +87,6 @@
 					"name": "constant.numeric"
 				}
 			},
-			"patterns": []
-		},
-		"param": {
-			"match": "(@|this.)([a-zA-Z0-9_.-]+)",
-			"captures": {
-				"0": {
-					"name": "support.function",
-					"patterns": [
-						{
-							"name": "variable.language",
-							"match": "(@|this)"
-						},
-						{
-							"name": "punctuation.definition.tag",
-							"match": "(\\.)+"
-						}
-					]
-				},
-				"1": {
-					"name": "support.function",
-					"patterns": [
-						{
-							"name": "punctuation.definition.tag",
-							"match": "(\\.)+"
-						}
-					]
-				}
-			},
-			"patterns": []
-		},
-		"attention": {
-			"name": "storage.type.class.${1:/downcase}",
-			"match": "@?(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|TEMP)\\b",
-			"patterns": []
-		},
-		"glimmer-unescaped-expression": {
-			"name": "entity.unescaped.expression.ember-handlebars",
-			"begin": "{{{",
-			"end": "}}}",
-			"captures": {
-				"0": {
-					"name": "keyword.operator"
-				}
-			},
-			"patterns": [
-				{
-					"include": "#string-single-quoted-handlebars"
-				},
-				{
-					"include": "#string-double-quoted-handlebars"
-				},
-				{
-					"include": "#glimmer-subexp"
-				},
-				{
-					"include": "#param"
-				}
-			]
-		},
-		"glimmer-comment-block": {
-			"name": "comment.block.glimmer",
-			"begin": "{{!--",
-			"end": "--}}",
-			"captures": {
-				"0": {
-					"name": "punctuation.definition.block.comment.glimmer"
-				}
-			},
-			"patterns": [
-				{
-					"include": "#script"
-				},
-				{
-					"include": "#attention"
-				}
-			]
-		},
-		"glimmer-comment-inline": {
-			"name": "comment.inline.glimmer",
-			"begin": "{{!",
-			"end": "}}",
-			"captures": {
-				"0": {
-					"name": "punctuation.definition.block.comment.glimmer"
-				}
-			},
-			"patterns": [
-				{
-					"include": "#script"
-				},
-				{
-					"include": "#attention"
-				}
-			]
-		},
-		"glimmer-bools": {
-			"name": "entity.expression.ember-handlebars",
-			"match": "({{~?)(true|false|null|undefined|\\d*(\\.)?\\d+)(~?}})",
-			"captures": {
-				"0": {
-					"name": "keyword.operator"
-				},
-				"1": {
-					"name": "keyword.operator"
-				},
-				"2": {
-					"name": "string.regexp"
-				},
-				"3": {
-					"name": "string.regexp"
-				},
-				"4": {
-					"name": "keyword.operator"
-				}
-			}
-		},
-		"glimmer-else-block": {
-			"name": "entity.expression.ember-handlebars",
-			"match": "({{~?)(else\\s[a-z]+\\s|else)([()@a-zA-Z0-9\\.\\s\\b]+)?(~?}})",
-			"captures": {
-				"0": {
-					"name": "punctuation.definition.tag"
-				},
-				"1": {
-					"name": "punctuation.definition.tag"
-				},
-				"2": {
-					"name": "keyword.control"
-				},
-				"3": {
-					"name": "keyword.control",
-					"patterns": [
-						{
-							"include": "#glimmer-subexp"
-						},
-						{
-							"include": "#string-single-quoted-handlebars"
-						},
-						{
-							"include": "#string-double-quoted-handlebars"
-						},
-						{
-							"include": "#boolean"
-						},
-						{
-							"include": "#digit"
-						},
-						{
-							"include": "#param"
-						},
-						{
-							"include": "#glimmer-parameter-name"
-						},
-						{
-							"include": "#glimmer-parameter-value"
-						}
-					]
-				},
-				"4": {
-					"name": "punctuation.definition.tag"
-				}
-			}
-		},
-		"glimmer-special-block": {
-			"name": "entity.expression.ember-handlebars",
-			"match": "({{~?)(yield|outlet)(~?}})",
-			"captures": {
-				"0": {
-					"name": "keyword.operator"
-				},
-				"1": {
-					"name": "keyword.operator"
-				},
-				"2": {
-					"name": "keyword.control"
-				},
-				"3": {
-					"name": "keyword.operator"
-				}
-			}
-		},
-		"glimmer-as-stuff": {
-			"patterns": [
-				{
-					"include": "#as-keyword"
-				},
-				{
-					"include": "#as-params"
-				}
-			]
-		},
-		"glimmer-block": {
-			"name": "entity.expression.ember-handlebars",
-			"begin": "({{~?)(#|/)(([@\\$a-zA-Z0-9_/.-]+))",
-			"end": "(~?}})",
-			"captures": {
-				"1": {
-					"name": "punctuation.definition.tag"
-				},
-				"2": {
-					"name": "punctuation.definition.tag"
-				},
-				"3": {
-					"name": "keyword.control",
-					"patterns": [
-						{
-							"include": "#glimmer-component-path"
-						},
-						{
-							"name": "punctuation.definition.tag",
-							"match": "(\\/)+"
-						},
-						{
-							"name": "punctuation.definition.tag",
-							"match": "(\\.)+"
-						}
-					]
-				}
-			},
-			"patterns": [
-				{
-					"include": "#glimmer-as-stuff"
-				},
-				{
-					"include": "#glimmer-supexp-content"
-				}
-			]
-		},
-		"glimmer-expression-property": {
-			"name": "entity.expression.ember-handlebars",
-			"begin": "({{~?)((@|this.)([a-zA-Z0-9_.-]+))",
-			"end": "(~?}})",
-			"captures": {
-				"1": {
-					"name": "keyword.operator"
-				},
-				"2": {
-					"name": "keyword.operator"
-				},
-				"3": {
-					"name": "support.function",
-					"patterns": [
-						{
-							"name": "variable.language",
-							"match": "(@|this)"
-						},
-						{
-							"name": "punctuation.definition.tag",
-							"match": "(\\.)+"
-						}
-					]
-				},
-				"4": {
-					"name": "support.function",
-					"patterns": [
-						{
-							"name": "punctuation.definition.tag",
-							"match": "(\\.)+"
-						}
-					]
-				}
-			},
-			"patterns": [
-				{
-					"include": "#glimmer-supexp-content"
-				}
-			]
-		},
-		"glimmer-expression": {
-			"name": "entity.expression.ember-handlebars",
-			"begin": "({{~?)(([()\\s@a-zA-Z0-9_.-]+))",
-			"end": "(~?}})",
-			"captures": {
-				"1": {
-					"name": "keyword.operator"
-				},
-				"2": {
-					"name": "keyword.operator"
-				},
-				"3": {
-					"name": "support.function",
-					"patterns": [
-						{
-							"name": "string.regexp",
-							"match": "[(]+"
-						},
-						{
-							"name": "string.regexp",
-							"match": "[)]+"
-						},
-						{
-							"name": "punctuation.definition.tag",
-							"match": "(\\.)+"
-						},
-						{
-							"include": "#glimmer-supexp-content"
-						}
-					]
-				}
-			},
-			"patterns": [
-				{
-					"include": "#glimmer-supexp-content"
-				}
-			]
-		},
-		"glimmer-supexp-content": {
-			"patterns": [
-				{
-					"include": "#glimmer-subexp"
-				},
-				{
-					"include": "#string-single-quoted-handlebars"
-				},
-				{
-					"include": "#string-double-quoted-handlebars"
-				},
-				{
-					"include": "#boolean"
-				},
-				{
-					"include": "#digit"
-				},
-				{
-					"include": "#param"
-				},
-				{
-					"include": "#glimmer-parameter-name"
-				},
-				{
-					"include": "#glimmer-parameter-value"
-				}
-			]
-		},
-		"glimmer-control-expression": {
-			"name": "entity.expression.ember-handlebars",
-			"begin": "({{~?)(([-a-zA-Z_0-9/]+)\\s)",
-			"end": "(~?}})",
-			"captures": {
-				"1": {
-					"name": "keyword.operator"
-				},
-				"2": {
-					"name": "keyword.operator"
-				},
-				"3": {
-					"name": "keyword.control"
-				}
-			},
-			"patterns": [
-				{
-					"include": "#glimmer-supexp-content"
-				}
-			]
-		},
-		"glimmer-subexp": {
-			"name": "entity.subexpression.ember-handlebars",
-			"begin": "(\\()([@a-zA-Z0-9.-]+)",
-			"end": "(\\))",
-			"captures": {
-				"1": {
-					"name": "keyword.other"
-				},
-				"2": {
-					"name": "keyword.control"
-				}
-			},
-			"patterns": [
-				{
-					"include": "#glimmer-supexp-content"
-				}
-			]
-		},
-		"as-keyword": {
-			"name": "keyword.control",
-			"match": "\\s\\b(as)\\b(?=\\s\\|)",
-			"patterns": []
-		},
-		"as-params": {
-			"name": "keyword.block-params.ember-handlebars",
-			"begin": "(?<!\\|)(\\|)",
-			"beginCaptures": {
-				"1": {
-					"name": "constant.other.symbol.begin.ember-handlebars"
-				}
-			},
-			"end": "(\\|)(?!\\|)",
-			"endCaptures": {
-				"1": {
-					"name": "constant.other.symbol.end.ember-handlebars"
-				}
-			},
-			"patterns": [
-				{
-					"include": "#variable"
-				}
-			]
-		},
-		"glimmer-parameter-value": {
-			"match": "\\b([a-zA-Z0-9:_.-]+)\\b(?!=)",
-			"captures": {
-				"1": {
-					"name": "support.function",
-					"patterns": [
-						{
-							"name": "punctuation.definition.tag",
-							"match": "(\\.)+"
-						}
-					]
-				}
-			},
-			"patterns": []
-		},
-		"glimmer-parameter-name": {
-			"match": "\\b([a-zA-Z0-9_-]+)(\\s?=)",
-			"captures": {
-				"1": {
-					"name": "variable.parameter.name.ember-handlebars"
-				},
-				"2": {
-					"name": "punctuation.definition.expression.ember-handlebars"
-				}
-			},
-			"patterns": []
-		},
-		"variable": {
-			"name": "support.function",
-			"match": "\\b([a-zA-Z0-9-_]+)\\b",
 			"patterns": []
 		},
 		"style": {
@@ -692,7 +147,7 @@
 							"name": "meta.tag.metadata.style.start.html",
 							"patterns": [
 								{
-									"include": "#glimmer-argument"
+									"include": "#lit-html-attribute-binding"
 								},
 								{
 									"include": "#html-attribute"
@@ -873,7 +328,7 @@
 									"include": "#string-single-quoted-html"
 								},
 								{
-									"include": "#glimmer-argument"
+									"include": "#lit-html-attribute-binding"
 								},
 								{
 									"include": "#html-attribute"
@@ -885,55 +340,28 @@
 			]
 		},
 		"html-comment": {
-			"name": "comment.block.html.ember-handlebars",
+			"name": "comment.block.html.lit-template",
 			"begin": "<!--",
 			"end": "--\\s*>",
 			"captures": {
 				"0": {
-					"name": "punctuation.definition.comment.html.ember-handlebars"
+					"name": "punctuation.definition.comment.html.lit-template"
 				}
 			},
 			"patterns": [
 				{
-					"include": "#attention"
-				},
-				{
 					"match": "--",
-					"name": "invalid.illegal.bad-comments-or-CDATA.html.ember-handlebars"
+					"name": "invalid.illegal.bad-comments-or-CDATA.html.lit-template"
 				}
 			]
 		},
 		"tag-like-content": {
 			"patterns": [
 				{
-					"include": "#glimmer-bools"
-				},
-				{
-					"include": "#glimmer-unescaped-expression"
-				},
-				{
-					"include": "#glimmer-comment-block"
-				},
-				{
-					"include": "#glimmer-comment-inline"
-				},
-				{
-					"include": "#glimmer-expression-property"
-				},
-				{
 					"include": "#boolean"
 				},
 				{
 					"include": "#digit"
-				},
-				{
-					"include": "#glimmer-control-expression"
-				},
-				{
-					"include": "#glimmer-expression"
-				},
-				{
-					"include": "#glimmer-block"
 				},
 				{
 					"include": "#string-double-quoted-html"
@@ -942,73 +370,22 @@
 					"include": "#string-single-quoted-html"
 				},
 				{
-					"include": "#glimmer-as-stuff"
-				},
-				{
-					"include": "#glimmer-argument"
+					"include": "#lit-html-attribute-binding"
 				},
 				{
 					"include": "#html-attribute"
 				}
 			]
 		},
-		"component-tag": {
-			"name": "meta.tag.any.ember-handlebars",
-			"begin": "(<\\/?)(@|this.)?([a-zA-Z0-9-_\\$:\\.]+)\\b",
-			"beginCaptures": {
-				"1": {
-					"name": "punctuation.definition.tag"
-				},
-				"2": {
-					"name": "support.function",
-					"patterns": [
-						{
-							"name": "variable.language",
-							"match": "(@|this)"
-						},
-						{
-							"name": "punctuation.definition.tag",
-							"match": "(\\.)+"
-						}
-					]
-				},
-				"3": {
-					"name": "entity.name.type",
-					"patterns": [
-						{
-							"include": "#glimmer-component-path"
-						},
-						{
-							"name": "markup.bold",
-							"match": "(@|:|\\$)"
-						}
-					]
-				}
-			},
-			"end": "(\\/?)(>)",
-			"endCaptures": {
-				"1": {
-					"name": "punctuation.definition.tag"
-				},
-				"2": {
-					"name": "punctuation.definition.tag"
-				}
-			},
-			"patterns": [
-				{
-					"include": "#tag-like-content"
-				}
-			]
-		},
 		"html-tag": {
-			"name": "meta.tag.any.ember-handlebars",
+			"name": "meta.tag.any.lit-template",
 			"begin": "(<\\/?)([a-z0-9-]+)(?!\\.|:)\\b",
 			"beginCaptures": {
 				"1": {
 					"name": "punctuation.definition.tag"
 				},
 				"2": {
-					"name": "entity.name.tag.html.ember-handlebars"
+					"name": "entity.name.tag.html.lit-template"
 				}
 			},
 			"end": "(\\/?)(>)",
@@ -1026,20 +403,20 @@
 				}
 			]
 		},
-		"glimmer-argument": {
-			"match": "\\s(@[a-zA-Z0-9:_.-]+)(=)?",
+		"lit-html-attribute-binding": {
+			"match": "\\s((@|\\?)[a-zA-Z0-9:_.-]+)(=)?",
 			"captures": {
 				"1": {
-					"name": "entity.other.attribute-name.ember-handlebars.argument",
+					"name": "entity.other.attribute-name.lit-template.argument",
 					"patterns": [
 						{
 							"name": "markup.italic",
-							"match": "(@)"
+							"match": "(@|\\?)"
 						}
 					]
 				},
-				"2": {
-					"name": "punctuation.separator.key-value.html.ember-handlebars"
+				"3": {
+					"name": "punctuation.separator.key-value.html.lit-template"
 				}
 			}
 		},
@@ -1047,38 +424,12 @@
 			"match": "\\s([a-zA-Z0-9:_.-]+)(=)?",
 			"captures": {
 				"1": {
-					"name": "entity.other.attribute-name.ember-handlebars",
-					"patterns": [
-						{
-							"name": "markup.bold",
-							"match": "(\\.\\.\\.attributes)"
-						}
-					]
+					"name": "entity.other.attribute-name.lit-template"
 				},
 				"2": {
-					"name": "punctuation.separator.key-value.html.ember-handlebars"
+					"name": "punctuation.separator.key-value.html.lit-template"
 				}
 			}
-		},
-		"entities": {
-			"patterns": [
-				{
-					"name": "constant.character.entity.html.ember-handlebars",
-					"match": "(&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)(;)",
-					"captures": {
-						"1": {
-							"name": "punctuation.definition.entity.html.ember-handlebars"
-						},
-						"3": {
-							"name": "punctuation.definition.entity.html.ember-handlebars"
-						}
-					}
-				},
-				{
-					"name": "invalid.illegal.bad-ampersand.html.ember-handlebars",
-					"match": "&"
-				}
-			]
 		}
 	}
 }

--- a/packages/vscode-lit-plugin/syntaxes/vscode-lit-html/text.html.lit-template.json
+++ b/packages/vscode-lit-plugin/syntaxes/vscode-lit-html/text.html.lit-template.json
@@ -1,0 +1,1084 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "Glimmer",
+	"scopeName": "text.html.ember-handlebars",
+	"fileTypes": ["hbs"],
+	"patterns": [
+		{
+			"include": "#style"
+		},
+		{
+			"include": "#script"
+		},
+		{
+			"include": "#glimmer-else-block"
+		},
+		{
+			"include": "#glimmer-bools"
+		},
+		{
+			"include": "#glimmer-special-block"
+		},
+		{
+			"include": "#glimmer-unescaped-expression"
+		},
+		{
+			"include": "#glimmer-comment-block"
+		},
+		{
+			"include": "#glimmer-comment-inline"
+		},
+		{
+			"include": "#glimmer-expression-property"
+		},
+		{
+			"include": "#glimmer-control-expression"
+		},
+		{
+			"include": "#glimmer-expression"
+		},
+		{
+			"include": "#glimmer-block"
+		},
+		{
+			"include": "#html-tag"
+		},
+		{
+			"include": "#component-tag"
+		},
+		{
+			"include": "#html-comment"
+		},
+		{
+			"include": "#entities"
+		}
+	],
+	"repository": {
+		"glimmer-component-path": {
+			"match": "(::|_|\\$|\\.)",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.tag"
+				}
+			}
+		},
+		"string-double-quoted-handlebars": {
+			"name": "string.quoted.double.ember-handlebars",
+			"begin": "\"",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.ember-handlebars"
+				}
+			},
+			"end": "\"",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.end.ember-handlebars"
+				}
+			},
+			"patterns": [
+				{
+					"name": "constant.character.escape.ember-handlebars",
+					"match": "\\\\\""
+				}
+			]
+		},
+		"string-single-quoted-handlebars": {
+			"name": "string.quoted.single.ember-handlebars",
+			"begin": "'",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.ember-handlebars"
+				}
+			},
+			"end": "'",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.end.ember-handlebars"
+				}
+			},
+			"patterns": [
+				{
+					"name": "constant.character.escape.ember-handlebars",
+					"match": "\\\\'"
+				}
+			]
+		},
+		"string-double-quoted-html": {
+			"name": "string.quoted.double.html.ember-handlebars",
+			"begin": "\"",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.ember-handlebars"
+				}
+			},
+			"end": "\"",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.end.ember-handlebars"
+				}
+			},
+			"patterns": [
+				{
+					"name": "constant.character.escape.ember-handlebars",
+					"match": "\\\\\""
+				},
+				{
+					"include": "#glimmer-bools"
+				},
+				{
+					"include": "#glimmer-expression-property"
+				},
+				{
+					"include": "#glimmer-control-expression"
+				},
+				{
+					"include": "#glimmer-expression"
+				},
+				{
+					"include": "#glimmer-block"
+				}
+			]
+		},
+		"string-single-quoted-html": {
+			"name": "string.quoted.single.html.ember-handlebars",
+			"begin": "'",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.ember-handlebars"
+				}
+			},
+			"end": "'",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.end.ember-handlebars"
+				}
+			},
+			"patterns": [
+				{
+					"name": "constant.character.escape.ember-handlebars",
+					"match": "\\\\'"
+				},
+				{
+					"include": "#glimmer-bools"
+				},
+				{
+					"include": "#glimmer-expression-property"
+				},
+				{
+					"include": "#glimmer-control-expression"
+				},
+				{
+					"include": "#glimmer-expression"
+				},
+				{
+					"include": "#glimmer-block"
+				}
+			]
+		},
+		"boolean": {
+			"match": "true|false|undefined|null",
+			"captures": {
+				"0": {
+					"name": "string.regexp"
+				},
+				"1": {
+					"name": "string.regexp"
+				},
+				"2": {
+					"name": "string.regexp"
+				}
+			},
+			"patterns": []
+		},
+		"digit": {
+			"match": "\\d*(\\.)?\\d+",
+			"captures": {
+				"0": {
+					"name": "constant.numeric"
+				},
+				"1": {
+					"name": "constant.numeric"
+				},
+				"2": {
+					"name": "constant.numeric"
+				}
+			},
+			"patterns": []
+		},
+		"param": {
+			"match": "(@|this.)([a-zA-Z0-9_.-]+)",
+			"captures": {
+				"0": {
+					"name": "support.function",
+					"patterns": [
+						{
+							"name": "variable.language",
+							"match": "(@|this)"
+						},
+						{
+							"name": "punctuation.definition.tag",
+							"match": "(\\.)+"
+						}
+					]
+				},
+				"1": {
+					"name": "support.function",
+					"patterns": [
+						{
+							"name": "punctuation.definition.tag",
+							"match": "(\\.)+"
+						}
+					]
+				}
+			},
+			"patterns": []
+		},
+		"attention": {
+			"name": "storage.type.class.${1:/downcase}",
+			"match": "@?(TODO|FIXME|CHANGED|XXX|IDEA|HACK|NOTE|REVIEW|NB|BUG|QUESTION|TEMP)\\b",
+			"patterns": []
+		},
+		"glimmer-unescaped-expression": {
+			"name": "entity.unescaped.expression.ember-handlebars",
+			"begin": "{{{",
+			"end": "}}}",
+			"captures": {
+				"0": {
+					"name": "keyword.operator"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#string-single-quoted-handlebars"
+				},
+				{
+					"include": "#string-double-quoted-handlebars"
+				},
+				{
+					"include": "#glimmer-subexp"
+				},
+				{
+					"include": "#param"
+				}
+			]
+		},
+		"glimmer-comment-block": {
+			"name": "comment.block.glimmer",
+			"begin": "{{!--",
+			"end": "--}}",
+			"captures": {
+				"0": {
+					"name": "punctuation.definition.block.comment.glimmer"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#script"
+				},
+				{
+					"include": "#attention"
+				}
+			]
+		},
+		"glimmer-comment-inline": {
+			"name": "comment.inline.glimmer",
+			"begin": "{{!",
+			"end": "}}",
+			"captures": {
+				"0": {
+					"name": "punctuation.definition.block.comment.glimmer"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#script"
+				},
+				{
+					"include": "#attention"
+				}
+			]
+		},
+		"glimmer-bools": {
+			"name": "entity.expression.ember-handlebars",
+			"match": "({{~?)(true|false|null|undefined|\\d*(\\.)?\\d+)(~?}})",
+			"captures": {
+				"0": {
+					"name": "keyword.operator"
+				},
+				"1": {
+					"name": "keyword.operator"
+				},
+				"2": {
+					"name": "string.regexp"
+				},
+				"3": {
+					"name": "string.regexp"
+				},
+				"4": {
+					"name": "keyword.operator"
+				}
+			}
+		},
+		"glimmer-else-block": {
+			"name": "entity.expression.ember-handlebars",
+			"match": "({{~?)(else\\s[a-z]+\\s|else)([()@a-zA-Z0-9\\.\\s\\b]+)?(~?}})",
+			"captures": {
+				"0": {
+					"name": "punctuation.definition.tag"
+				},
+				"1": {
+					"name": "punctuation.definition.tag"
+				},
+				"2": {
+					"name": "keyword.control"
+				},
+				"3": {
+					"name": "keyword.control",
+					"patterns": [
+						{
+							"include": "#glimmer-subexp"
+						},
+						{
+							"include": "#string-single-quoted-handlebars"
+						},
+						{
+							"include": "#string-double-quoted-handlebars"
+						},
+						{
+							"include": "#boolean"
+						},
+						{
+							"include": "#digit"
+						},
+						{
+							"include": "#param"
+						},
+						{
+							"include": "#glimmer-parameter-name"
+						},
+						{
+							"include": "#glimmer-parameter-value"
+						}
+					]
+				},
+				"4": {
+					"name": "punctuation.definition.tag"
+				}
+			}
+		},
+		"glimmer-special-block": {
+			"name": "entity.expression.ember-handlebars",
+			"match": "({{~?)(yield|outlet)(~?}})",
+			"captures": {
+				"0": {
+					"name": "keyword.operator"
+				},
+				"1": {
+					"name": "keyword.operator"
+				},
+				"2": {
+					"name": "keyword.control"
+				},
+				"3": {
+					"name": "keyword.operator"
+				}
+			}
+		},
+		"glimmer-as-stuff": {
+			"patterns": [
+				{
+					"include": "#as-keyword"
+				},
+				{
+					"include": "#as-params"
+				}
+			]
+		},
+		"glimmer-block": {
+			"name": "entity.expression.ember-handlebars",
+			"begin": "({{~?)(#|/)(([@\\$a-zA-Z0-9_/.-]+))",
+			"end": "(~?}})",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.tag"
+				},
+				"2": {
+					"name": "punctuation.definition.tag"
+				},
+				"3": {
+					"name": "keyword.control",
+					"patterns": [
+						{
+							"include": "#glimmer-component-path"
+						},
+						{
+							"name": "punctuation.definition.tag",
+							"match": "(\\/)+"
+						},
+						{
+							"name": "punctuation.definition.tag",
+							"match": "(\\.)+"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#glimmer-as-stuff"
+				},
+				{
+					"include": "#glimmer-supexp-content"
+				}
+			]
+		},
+		"glimmer-expression-property": {
+			"name": "entity.expression.ember-handlebars",
+			"begin": "({{~?)((@|this.)([a-zA-Z0-9_.-]+))",
+			"end": "(~?}})",
+			"captures": {
+				"1": {
+					"name": "keyword.operator"
+				},
+				"2": {
+					"name": "keyword.operator"
+				},
+				"3": {
+					"name": "support.function",
+					"patterns": [
+						{
+							"name": "variable.language",
+							"match": "(@|this)"
+						},
+						{
+							"name": "punctuation.definition.tag",
+							"match": "(\\.)+"
+						}
+					]
+				},
+				"4": {
+					"name": "support.function",
+					"patterns": [
+						{
+							"name": "punctuation.definition.tag",
+							"match": "(\\.)+"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#glimmer-supexp-content"
+				}
+			]
+		},
+		"glimmer-expression": {
+			"name": "entity.expression.ember-handlebars",
+			"begin": "({{~?)(([()\\s@a-zA-Z0-9_.-]+))",
+			"end": "(~?}})",
+			"captures": {
+				"1": {
+					"name": "keyword.operator"
+				},
+				"2": {
+					"name": "keyword.operator"
+				},
+				"3": {
+					"name": "support.function",
+					"patterns": [
+						{
+							"name": "string.regexp",
+							"match": "[(]+"
+						},
+						{
+							"name": "string.regexp",
+							"match": "[)]+"
+						},
+						{
+							"name": "punctuation.definition.tag",
+							"match": "(\\.)+"
+						},
+						{
+							"include": "#glimmer-supexp-content"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#glimmer-supexp-content"
+				}
+			]
+		},
+		"glimmer-supexp-content": {
+			"patterns": [
+				{
+					"include": "#glimmer-subexp"
+				},
+				{
+					"include": "#string-single-quoted-handlebars"
+				},
+				{
+					"include": "#string-double-quoted-handlebars"
+				},
+				{
+					"include": "#boolean"
+				},
+				{
+					"include": "#digit"
+				},
+				{
+					"include": "#param"
+				},
+				{
+					"include": "#glimmer-parameter-name"
+				},
+				{
+					"include": "#glimmer-parameter-value"
+				}
+			]
+		},
+		"glimmer-control-expression": {
+			"name": "entity.expression.ember-handlebars",
+			"begin": "({{~?)(([-a-zA-Z_0-9/]+)\\s)",
+			"end": "(~?}})",
+			"captures": {
+				"1": {
+					"name": "keyword.operator"
+				},
+				"2": {
+					"name": "keyword.operator"
+				},
+				"3": {
+					"name": "keyword.control"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#glimmer-supexp-content"
+				}
+			]
+		},
+		"glimmer-subexp": {
+			"name": "entity.subexpression.ember-handlebars",
+			"begin": "(\\()([@a-zA-Z0-9.-]+)",
+			"end": "(\\))",
+			"captures": {
+				"1": {
+					"name": "keyword.other"
+				},
+				"2": {
+					"name": "keyword.control"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#glimmer-supexp-content"
+				}
+			]
+		},
+		"as-keyword": {
+			"name": "keyword.control",
+			"match": "\\s\\b(as)\\b(?=\\s\\|)",
+			"patterns": []
+		},
+		"as-params": {
+			"name": "keyword.block-params.ember-handlebars",
+			"begin": "(?<!\\|)(\\|)",
+			"beginCaptures": {
+				"1": {
+					"name": "constant.other.symbol.begin.ember-handlebars"
+				}
+			},
+			"end": "(\\|)(?!\\|)",
+			"endCaptures": {
+				"1": {
+					"name": "constant.other.symbol.end.ember-handlebars"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#variable"
+				}
+			]
+		},
+		"glimmer-parameter-value": {
+			"match": "\\b([a-zA-Z0-9:_.-]+)\\b(?!=)",
+			"captures": {
+				"1": {
+					"name": "support.function",
+					"patterns": [
+						{
+							"name": "punctuation.definition.tag",
+							"match": "(\\.)+"
+						}
+					]
+				}
+			},
+			"patterns": []
+		},
+		"glimmer-parameter-name": {
+			"match": "\\b([a-zA-Z0-9_-]+)(\\s?=)",
+			"captures": {
+				"1": {
+					"name": "variable.parameter.name.ember-handlebars"
+				},
+				"2": {
+					"name": "punctuation.definition.expression.ember-handlebars"
+				}
+			},
+			"patterns": []
+		},
+		"variable": {
+			"name": "support.function",
+			"match": "\\b([a-zA-Z0-9-_]+)\\b",
+			"patterns": []
+		},
+		"style": {
+			"begin": "(^[ \\t]+)?(?=<(?i:style)\\b(?!-))",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.whitespace.embedded.leading.html"
+				}
+			},
+			"end": "(?!\\G)([ \\t]*$\\n?)?",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.whitespace.embedded.trailing.html"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(?i)(<)(style)(?=\\s|/?>)",
+					"beginCaptures": {
+						"0": {
+							"name": "meta.tag.metadata.style.start.html"
+						},
+						"1": {
+							"name": "punctuation.definition.tag.begin.html"
+						},
+						"2": {
+							"name": "entity.name.tag.html"
+						}
+					},
+					"end": "(?i)((<)/)(style)\\s*(>)",
+					"endCaptures": {
+						"0": {
+							"name": "meta.tag.metadata.style.end.html"
+						},
+						"1": {
+							"name": "punctuation.definition.tag.begin.html"
+						},
+						"2": {
+							"name": "source.css-ignored-vscode"
+						},
+						"3": {
+							"name": "entity.name.tag.html"
+						},
+						"4": {
+							"name": "punctuation.definition.tag.end.html"
+						}
+					},
+					"name": "meta.embedded.block.html",
+					"patterns": [
+						{
+							"begin": "\\G",
+							"captures": {
+								"1": {
+									"name": "punctuation.definition.tag.end.html"
+								}
+							},
+							"end": "(>)",
+							"name": "meta.tag.metadata.style.start.html",
+							"patterns": [
+								{
+									"include": "#glimmer-argument"
+								},
+								{
+									"include": "#html-attribute"
+								}
+							]
+						},
+						{
+							"begin": "(?!\\G)",
+							"end": "(?=</(?i:style))",
+							"name": "source.css",
+							"patterns": [
+								{
+									"include": "source.css"
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		"script": {
+			"begin": "(^[ \\t]+)?(?=<(?i:script)\\b(?!-))",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.whitespace.embedded.leading.html"
+				}
+			},
+			"end": "(?!\\G)([ \\t]*$\\n?)?",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.whitespace.embedded.trailing.html"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(<)((?i:script))\\b",
+					"beginCaptures": {
+						"0": {
+							"name": "meta.tag.metadata.script.start.html"
+						},
+						"1": {
+							"name": "punctuation.definition.tag.begin.html"
+						},
+						"2": {
+							"name": "entity.name.tag.html"
+						}
+					},
+					"end": "(/)((?i:script))(>)",
+					"endCaptures": {
+						"0": {
+							"name": "meta.tag.metadata.script.end.html"
+						},
+						"1": {
+							"name": "punctuation.definition.tag.begin.html"
+						},
+						"2": {
+							"name": "entity.name.tag.html"
+						},
+						"3": {
+							"name": "punctuation.definition.tag.end.html"
+						}
+					},
+					"name": "meta.embedded.block.html",
+					"patterns": [
+						{
+							"begin": "\\G",
+							"end": "(?=/)",
+							"patterns": [
+								{
+									"begin": "(>)",
+									"beginCaptures": {
+										"0": {
+											"name": "meta.tag.metadata.script.start.html"
+										},
+										"1": {
+											"name": "punctuation.definition.tag.end.html"
+										}
+									},
+									"end": "((<))(?=/(?i:script))",
+									"endCaptures": {
+										"0": {
+											"name": "meta.tag.metadata.script.end.html"
+										},
+										"1": {
+											"name": "punctuation.definition.tag.begin.html"
+										},
+										"2": {
+											"name": "source.js-ignored-vscode"
+										}
+									},
+									"patterns": [
+										{
+											"begin": "\\G",
+											"end": "(?=</(?i:script))",
+											"name": "source.js",
+											"patterns": [
+												{
+													"begin": "(^[ \\t]+)?(?=//)",
+													"beginCaptures": {
+														"1": {
+															"name": "punctuation.whitespace.comment.leading.js"
+														}
+													},
+													"end": "(?!\\G)",
+													"patterns": [
+														{
+															"begin": "//",
+															"beginCaptures": {
+																"0": {
+																	"name": "punctuation.definition.comment.js"
+																}
+															},
+															"end": "(?=</script)|\\n",
+															"name": "comment.line.double-slash.js"
+														}
+													]
+												},
+												{
+													"begin": "/\\*",
+													"captures": {
+														"0": {
+															"name": "punctuation.definition.comment.js"
+														}
+													},
+													"end": "\\*/|(?=</script)",
+													"name": "comment.block.js"
+												},
+												{
+													"include": "source.js"
+												}
+											]
+										}
+									]
+								},
+								{
+									"begin": "(?ix:\n\t\t\t\t\t\t\t\t\t\t\t\t(?=\n\t\t\t\t\t\t\t\t\t\t\t\t\ttype\\s*=\\s*\n\t\t\t\t\t\t\t\t\t\t\t\t\t('|\"|)\n\t\t\t\t\t\t\t\t\t\t\t\t\ttext/\n\t\t\t\t\t\t\t\t\t\t\t\t\t(\n\t\t\t\t\t\t\t\t\t\t\t\t\t\tx-handlebars\n\t\t\t\t\t\t\t\t\t\t\t\t\t  | (x-(handlebars-)?|ng-)?template\n\t\t\t\t\t\t\t\t\t\t\t\t\t  | html\n\t\t\t\t\t\t\t\t\t\t\t\t\t)\n\t\t\t\t\t\t\t\t\t\t\t\t\t[\\s\"'>]\n\t\t\t\t\t\t\t\t\t\t\t\t)\n\t\t\t\t\t\t\t\t\t\t\t)",
+									"end": "((<))(?=/(?i:script))",
+									"endCaptures": {
+										"0": {
+											"name": "meta.tag.metadata.script.end.html"
+										},
+										"1": {
+											"name": "punctuation.definition.tag.begin.html"
+										},
+										"2": {
+											"name": "text.html.basic"
+										}
+									},
+									"patterns": [
+										{
+											"begin": "(?!\\G)",
+											"end": "(?=</(?i:script))",
+											"name": "text.html.basic",
+											"patterns": [
+												{
+													"include": "text.html.basic"
+												}
+											]
+										}
+									]
+								},
+								{
+									"begin": "(?=(?i:type))",
+									"end": "(<)(?=/(?i:script))",
+									"endCaptures": {
+										"0": {
+											"name": "meta.tag.metadata.script.end.html"
+										},
+										"1": {
+											"name": "punctuation.definition.tag.begin.html"
+										}
+									}
+								},
+								{
+									"include": "#string-double-quoted-html"
+								},
+								{
+									"include": "#string-single-quoted-html"
+								},
+								{
+									"include": "#glimmer-argument"
+								},
+								{
+									"include": "#html-attribute"
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		"html-comment": {
+			"name": "comment.block.html.ember-handlebars",
+			"begin": "<!--",
+			"end": "--\\s*>",
+			"captures": {
+				"0": {
+					"name": "punctuation.definition.comment.html.ember-handlebars"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#attention"
+				},
+				{
+					"match": "--",
+					"name": "invalid.illegal.bad-comments-or-CDATA.html.ember-handlebars"
+				}
+			]
+		},
+		"tag-like-content": {
+			"patterns": [
+				{
+					"include": "#glimmer-bools"
+				},
+				{
+					"include": "#glimmer-unescaped-expression"
+				},
+				{
+					"include": "#glimmer-comment-block"
+				},
+				{
+					"include": "#glimmer-comment-inline"
+				},
+				{
+					"include": "#glimmer-expression-property"
+				},
+				{
+					"include": "#boolean"
+				},
+				{
+					"include": "#digit"
+				},
+				{
+					"include": "#glimmer-control-expression"
+				},
+				{
+					"include": "#glimmer-expression"
+				},
+				{
+					"include": "#glimmer-block"
+				},
+				{
+					"include": "#string-double-quoted-html"
+				},
+				{
+					"include": "#string-single-quoted-html"
+				},
+				{
+					"include": "#glimmer-as-stuff"
+				},
+				{
+					"include": "#glimmer-argument"
+				},
+				{
+					"include": "#html-attribute"
+				}
+			]
+		},
+		"component-tag": {
+			"name": "meta.tag.any.ember-handlebars",
+			"begin": "(<\\/?)(@|this.)?([a-zA-Z0-9-_\\$:\\.]+)\\b",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.tag"
+				},
+				"2": {
+					"name": "support.function",
+					"patterns": [
+						{
+							"name": "variable.language",
+							"match": "(@|this)"
+						},
+						{
+							"name": "punctuation.definition.tag",
+							"match": "(\\.)+"
+						}
+					]
+				},
+				"3": {
+					"name": "entity.name.type",
+					"patterns": [
+						{
+							"include": "#glimmer-component-path"
+						},
+						{
+							"name": "markup.bold",
+							"match": "(@|:|\\$)"
+						}
+					]
+				}
+			},
+			"end": "(\\/?)(>)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.tag"
+				},
+				"2": {
+					"name": "punctuation.definition.tag"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#tag-like-content"
+				}
+			]
+		},
+		"html-tag": {
+			"name": "meta.tag.any.ember-handlebars",
+			"begin": "(<\\/?)([a-z0-9-]+)(?!\\.|:)\\b",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.tag"
+				},
+				"2": {
+					"name": "entity.name.tag.html.ember-handlebars"
+				}
+			},
+			"end": "(\\/?)(>)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.tag"
+				},
+				"2": {
+					"name": "punctuation.definition.tag"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#tag-like-content"
+				}
+			]
+		},
+		"glimmer-argument": {
+			"match": "\\s(@[a-zA-Z0-9:_.-]+)(=)?",
+			"captures": {
+				"1": {
+					"name": "entity.other.attribute-name.ember-handlebars.argument",
+					"patterns": [
+						{
+							"name": "markup.italic",
+							"match": "(@)"
+						}
+					]
+				},
+				"2": {
+					"name": "punctuation.separator.key-value.html.ember-handlebars"
+				}
+			}
+		},
+		"html-attribute": {
+			"match": "\\s([a-zA-Z0-9:_.-]+)(=)?",
+			"captures": {
+				"1": {
+					"name": "entity.other.attribute-name.ember-handlebars",
+					"patterns": [
+						{
+							"name": "markup.bold",
+							"match": "(\\.\\.\\.attributes)"
+						}
+					]
+				},
+				"2": {
+					"name": "punctuation.separator.key-value.html.ember-handlebars"
+				}
+			}
+		},
+		"entities": {
+			"patterns": [
+				{
+					"name": "constant.character.entity.html.ember-handlebars",
+					"match": "(&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)(;)",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.entity.html.ember-handlebars"
+						},
+						"3": {
+							"name": "punctuation.definition.entity.html.ember-handlebars"
+						}
+					}
+				},
+				{
+					"name": "invalid.illegal.bad-ampersand.html.ember-handlebars",
+					"match": "&"
+				}
+			]
+		}
+	}
+}


### PR DESCRIPTION
The aim here is to slightly improve the syntaxes by adding a custom `text.html` for Lit's tagged template literals. The previous version used `"text.html.basic"` which works very well in most cases, but I noticed that it would sometimes have issues in the occasional Lit template.

I used the syntaxes from [vsc-ember-syntax](https://github.com/lifeart/vsc-ember-syntax/tree/master/syntaxes) for reference with these. They were a big help in figuring out how to structure this - so thank you to the original author(s)! The versions here are based on those, but greatly simplified (Lit does not use handlebars or other Glimmer features) and adjusted a bit to support Lit templates.

I don't think most users will notice any major difference from this change. In the majority of cases the `html` templates will look exactly the same as before. 

The one part that I am a little unsure about from the new syntax is the `#script` block. I left that as-is from the `vsc-ember-syntax` version for now, but it might be possible to reduce that one a little further for Lit.

Closes #263 