### PR TITLE
chore: Ran `npm audit fix` to address vulnerabilities

### DIFF
--- a/.changeset/deep-ways-heal.md
+++ b/.changeset/deep-ways-heal.md
@@ -1,0 +1,5 @@
+---
+"lit-analyzer-plugin": patch
+---
+
+Update minor vulnerable package versions using npm audit fix

--- a/package-lock.json
+++ b/package-lock.json
@@ -10388,7 +10388,9 @@
 			}
 		},
 		"node_modules/tar-fs": {
-			"version": "2.1.1",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
+			"integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -10895,7 +10897,9 @@
 			"license": "MIT"
 		},
 		"node_modules/undici": {
-			"version": "6.21.0",
+			"version": "6.21.2",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
+			"integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {


### PR DESCRIPTION
tar-fs vulnerability:
https://security.snyk.io/vuln/SNYK-JS-TARFS-9535930

undici vulnerability:
https://security.snyk.io/vuln/SNYK-JS-UNDICI-8641354

These dependencies are only used as part of the VSCode extension and are installed via the `@vscode/vsce` package.