### PR TITLE
chore: Generate dependency update changesets

### DIFF
--- a/.changeset/wide-cooks-mate.md
+++ b/.changeset/wide-cooks-mate.md
@@ -1,0 +1,8 @@
+---
+"@jackolope/lit-analyzer": patch
+"@jackolope/ts-lit-plugin": patch
+"lit-analyzer-plugin": patch
+"@jackolope/web-component-analyzer": patch
+---
+
+fix: Upgrade patch npm audit dependencies to fix vulnerabilities

--- a/.changeset/zzz_dependabot-9af072e-@jackolope-lit-analyzer.md
+++ b/.changeset/zzz_dependabot-9af072e-@jackolope-lit-analyzer.md
@@ -1,0 +1,10 @@
+---
+"@jackolope/lit-analyzer": minor
+---
+
+Updated dependencies:
+Updated dependency `@vscode/web-custom-data` to `^0.6.0`.
+Updated dependency `vscode-css-languageservice` to `6.3.6`.
+Updated dependency `vscode-html-languageservice` to `5.5.0`.
+Updated devDependency `@types/node` to `^22.15.30`.
+Updated devDependency `ava` to `^6.4.0`.

--- a/.changeset/zzz_dependabot-9af072e-@jackolope-ts-lit-plugin.md
+++ b/.changeset/zzz_dependabot-9af072e-@jackolope-ts-lit-plugin.md
@@ -1,0 +1,7 @@
+---
+"@jackolope/ts-lit-plugin": patch
+---
+
+Updated dependencies:
+Updated devDependency `@types/node` to `^22.15.30`.
+Updated devDependency `esbuild` to `^0.25.5`.

--- a/.changeset/zzz_dependabot-9af072e-@jackolope-web-component-analyzer.md
+++ b/.changeset/zzz_dependabot-9af072e-@jackolope-web-component-analyzer.md
@@ -1,0 +1,8 @@
+---
+"@jackolope/web-component-analyzer": patch
+---
+
+Updated dependencies:
+Updated devDependency `@types/node` to `^22.15.30`.
+Updated devDependency `ava` to `^6.4.0`.
+Updated devDependency `rollup` to `^4.43.0`.

--- a/.changeset/zzz_dependabot-9af072e-lit-analyzer-plugin.md
+++ b/.changeset/zzz_dependabot-9af072e-lit-analyzer-plugin.md
@@ -1,0 +1,11 @@
+---
+"lit-analyzer-plugin": minor
+---
+
+Updated dependencies:
+Updated dependency `@vscode/vsce` to `^3.5.0`.
+Updated dependency `vscode-css-languageservice` to `6.3.6`.
+Updated dependency `vscode-html-languageservice` to `5.5.0`.
+Updated devDependency `@types/node` to `^22.15.30`.
+Updated devDependency `esbuild` to `^0.25.5`.
+Updated devDependency `mocha` to `^11.6.0`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2834,9 +2834,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2942,9 +2942,9 @@
 			}
 		},
 		"node_modules/@vercel/nft/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3236,10 +3236,11 @@
 			}
 		},
 		"node_modules/@vscode/vsce/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
@@ -4091,7 +4092,9 @@
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.11",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7930,7 +7933,9 @@
 			}
 		},
 		"node_modules/mocha/node_modules/brace-expansion": {
-			"version": "2.0.1",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10505,9 +10510,9 @@
 			}
 		},
 		"node_modules/tar-fs": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
-			"integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+			"integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -11338,9 +11343,9 @@
 			}
 		},
 		"node_modules/wireit/node_modules/brace-expansion": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-4.0.0.tgz",
-			"integrity": "sha512-l/mOwLWs7BQIgOKrL46dIAbyCKvPV7YJPDspkuc88rHsZRlg3hptUGdU7Trv0VFP4d3xnSGBQrKu5ZvGB7UeIw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-4.0.1.tgz",
+			"integrity": "sha512-YClrbvTCXGe70pU2JiEiPLYXO9gQkyxYeKpJIQHVS/gOs6EWMQP2RYBwjFLNT322Ji8TOC3IMPfsYCedNpzKfA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {


### PR DESCRIPTION
Changeset files to trigger the new release.

The only user-facing changes since the last release have been the `vscode` related dependencies, but it would be nice to do a small release to keep these up-to-date.

Also fixing two small `npm audit` issues in this PR.