### PR TITLE
fix: Update no-missing-import rule to avoid reporting on any listed globalTags

### DIFF
--- a/.changeset/slow-parents-sin.md
+++ b/.changeset/slow-parents-sin.md
@@ -1,0 +1,7 @@
+---
+"@jackolope/lit-analyzer": patch
+"@jackolope/ts-lit-plugin": patch
+"lit-analyzer-plugin": patch
+---
+
+Fix: Update no-missing-import rule to avoid reporting on any listed globalTags

--- a/packages/lit-analyzer/src/lib/rules/no-missing-import.ts
+++ b/packages/lit-analyzer/src/lib/rules/no-missing-import.ts
@@ -22,6 +22,10 @@ const rule: RuleModule = {
 		const isCustomElement = isCustomElementTagName(htmlNode.tagName);
 		if (!isCustomElement) return;
 
+		// Return if this is listed as one of the always present `globalTags` in the config
+		const isGlobalTag = context.config.globalTags.includes(htmlNode.tagName);
+		if (isGlobalTag) return;
+
 		// Don't continue if this tag name doesn't have a definition.
 		// If the html tag doesn't have a definition we won't know how to import it.
 		const definition = definitionStore.getDefinitionForTagName(htmlNode.tagName);

--- a/packages/lit-analyzer/src/test/rules/no-missing-import.ts
+++ b/packages/lit-analyzer/src/test/rules/no-missing-import.ts
@@ -9,6 +9,13 @@ tsTest("Report missing imports of custom elements", t => {
 	hasDiagnostic(t, diagnostics, "no-missing-import");
 });
 
+tsTest("Report missing imports of custom elements with a type-only import", t => {
+	const { diagnostics } = getDiagnostics([makeElement({}), "import type {} from './my-element'; html`<my-element></my-element>`"], {
+		rules: { "no-missing-import": true }
+	});
+	hasDiagnostic(t, diagnostics, "no-missing-import");
+});
+
 tsTest("Don't report missing imports when the custom element has been imported 1", t => {
 	const { diagnostics } = getDiagnostics([makeElement({}), "import './my-element'; html`<my-element></my-element>`"], {
 		rules: { "no-missing-import": true }
@@ -28,6 +35,14 @@ tsTest("Don't report missing imports when the custom element has been imported 2
 		],
 		{ rules: { "no-missing-import": true } }
 	);
+	hasNoDiagnostics(t, diagnostics);
+});
+
+tsTest("Don't report missing imports when the custom element is included in the globalTags config", t => {
+	const { diagnostics } = getDiagnostics([makeElement({}), "html`<my-element></my-element>`"], {
+		rules: { "no-missing-import": true },
+		globalTags: ["my-element"]
+	});
 	hasNoDiagnostics(t, diagnostics);
 });
 


### PR DESCRIPTION
Fixes this issue by skipping this rule for any tags that were listed in the `globalTags` config.

fixes: #299 

Also added a test separate test for the type-only import case that was fixed awhile ago in this PR:
https://github.com/JackRobards/lit-analyzer/pull/111