### PR TITLE
fix: ts-lit-plugin entry

### DIFF
--- a/.changeset/khaki-rats-drive.md
+++ b/.changeset/khaki-rats-drive.md
@@ -1,0 +1,5 @@
+---
+"@jackolope/ts-lit-plugin": patch
+---
+
+fix: ts-lit-plugin entry

--- a/packages/ts-lit-plugin/index.js
+++ b/packages/ts-lit-plugin/index.js
@@ -2,4 +2,4 @@
 // we can't express that in proper ESM, so this hand-written JS
 // file bridges the difference.
 
-module.exports = require("./lib/index").init;
+module.exports = require("./lib/src/index").init;


### PR DESCRIPTION
The ts-lit-plugin entry does not seem to point at the correct module.

```
$ ls node_modules/@jackolope/ts-lit-plugin/lib/index*
zsh: no matches found: node_modules/@jackolope/ts-lit-plugin/lib/index*

$ ls node_modules/@jackolope/ts-lit-plugin/lib/src/index*
node_modules/@jackolope/ts-lit-plugin/lib/src/index.d.ts
node_modules/@jackolope/ts-lit-plugin/lib/src/index.d.ts.map
node_modules/@jackolope/ts-lit-plugin/lib/src/index.js
node_modules/@jackolope/ts-lit-plugin/lib/src/index.js.map
```

After the fix, the plugin gets properly loaded and I get intellisense in neovim again.