### PR TITLE
fix: Remove cross package dependency from the vscode lit plugin build 

### DIFF
--- a/.changeset/yellow-boxes-hang.md
+++ b/.changeset/yellow-boxes-hang.md
@@ -1,0 +1,5 @@
+---
+"lit-analyzer-plugin": patch
+---
+
+fix: Remove the cross-package dependency on the ts-lit-plugin/index.js file from the vscode-lit-plugin package. Required for a build fix in ts-lit-plugin but the vscode extension should continue to work the same as before this version.

--- a/packages/vscode-lit-plugin/copy-to-built.js
+++ b/packages/vscode-lit-plugin/copy-to-built.js
@@ -26,7 +26,9 @@ async function main() {
 	// dependencies.
 	tsPluginPackageJson.dependencies = {};
 	await writeFile("./built/node_modules/@jackolope/ts-lit-plugin/package.json", JSON.stringify(tsPluginPackageJson, null, 2));
-	await copy("../ts-lit-plugin/index.js", "./built/node_modules/@jackolope/ts-lit-plugin/index.js");
+
+	// We need to re-export the ts-lit plugin build output from a root index file
+	await writeFile("./built/node_modules/@jackolope/ts-lit-plugin/index.js", `module.exports = require("./lib/index").init;`);
 
 	const pluginPackageJson = require("./package.json");
 	// vsce is _very_ picky about the directories in node_modules matching the


### PR DESCRIPTION
Basically, allow the `ts-lit-plugin` to control it's own `index.js` entry file how it needs to without worrying about the vscode extension reaching across packages to copy the file directly.

Directly related to this PR:
https://github.com/JackRobards/lit-analyzer/pull/384

Some parts of the `copy-to-built.js` file still feels a little "hacky" to me, but this keeps it working while letting us fix the issue from the above PR in `ts-lit-plugin`.